### PR TITLE
V1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ SNVs trully present in the target strain will have a value of ``PASS`` in the ``
 
 ### Further filtering for a collection of samples 
 
-If you have run `cleansweep filter` on multiple plate swipes targeting the same strain, you can merge the resulting VCFs into a single multi-sample VCF with `cleansweep collection`. This step also removes sample-private variants from samples that are outliers in terms of ANI — i.e., samples that are unexpectedly dissimilar from all others, which may indicate insufficient filtering with `cleansweep filter`.
+If you have run `cleansweep filter` on multiple plate swipes targeting the same strain, you can merge the resulting VCFs into a single multi-sample VCF with `cleansweep collection`. This step detects samples that are unexpectedly dissimilar from all others in the dataset — likely indicating insufficient filtering by `cleansweep filter` — and either removes their sample-private variants or excludes them from the output entirely.
 
 ```
 cleansweep collection \
@@ -119,9 +119,42 @@ cleansweep collection \
 
 **How the outlier filter works:**
 
-1. For each sample in the merged VCF, CleanSweep computes the maximum ANI to other samples in the dataset. This results in a distribution of ANIs to the most similar sample in the dataset.
-2. The median and interquartile range (IQR) of these ANIs are computed.
-3. For each sample, the highest ANI it shares with any other sample is checked.
-4. If that maximum ANI falls below `median - alpha × IQR`, the sample is flagged as a divergent outlier and its sample-private variants (i.e., variants that only occur in that sample and not in any other sample in the dataset) are replaced with the per-site consensus of the remaining samples.
+1. For each sample in the merged VCF, CleanSweep computes the maximum ANI to any other sample in the dataset, producing one value per sample.
+2. The median and interquartile range (IQR) of these per-sample maximum ANIs are computed.
+3. Any sample whose maximum ANI falls below `median - alpha × IQR` is flagged as a divergent outlier.
+4. By default, flagged samples are cleaned in place: their sample-private variants (variants that appear only in that sample) are replaced with the per-site consensus genotype of the remaining samples.
 
-`--alpha` controls how aggressively outliers are detected. Larger values (default: 10) are more permissive and only flag extreme outliers; smaller values trigger further filtering for more samples.
+`--alpha` controls how aggressively outliers are detected. Larger values (default: 10) are more permissive and only flag extreme outliers; smaller values flag more samples.
+
+**Excluding outlier samples instead of cleaning them**
+
+Use `--exclude` to remove flagged samples from the merged VCF entirely rather than cleaning them:
+
+```
+cleansweep collection \
+    sample1/cleansweep.variants.vcf.gz \
+    sample2/cleansweep.variants.vcf.gz \
+    sample3/cleansweep.variants.vcf.gz \
+    --output merged.vcf \
+    --tmp-dir tmp/ \
+    --alpha 10 \
+    --exclude
+```
+
+When `--exclude` is set, flagged samples are dropped from the output VCF. Samples that are not flagged are unaffected.
+
+To record which samples were excluded, pass a file path to `--exclude-log`:
+
+```
+cleansweep collection \
+    sample1/cleansweep.variants.vcf.gz \
+    sample2/cleansweep.variants.vcf.gz \
+    sample3/cleansweep.variants.vcf.gz \
+    --output merged.vcf \
+    --tmp-dir tmp/ \
+    --alpha 10 \
+    --exclude \
+    --exclude-log excluded_samples.txt
+```
+
+CleanSweep will write the sample IDs of excluded samples to `excluded_samples.txt`, one per line. `--exclude-log` requires `--exclude` to be set.

--- a/cleansweep/cli/collection.py
+++ b/cleansweep/cli/collection.py
@@ -23,8 +23,12 @@ class CollectionCmd(Subcommand):
 
         io_grp.add_argument("input", type=str, nargs="+", help="CleanSweep VCFs to merge.")
         io_grp.add_argument("--output", "-o", type=str, help="Output VCF file.")
-        io_grp.add_argument("--tmp-dir", type=str, default="tmp/", 
+        io_grp.add_argument("--tmp-dir", type=str, default="tmp/",
             help="Temporary directory. Defaults to %(default)s.")
+        io_grp.add_argument("--exclude-log", type=str, default=None,
+            help="Path to write the IDs of samples excluded from the merged VCF (one "
+            "per line). Only meaningful together with --exclude; raises an error if "
+            "given without it. Defaults to no log file.")
 
         params_grp = parser.add_argument_group(
             "Filtering options",
@@ -38,10 +42,15 @@ class CollectionCmd(Subcommand):
             "all maximum ANIs - , variants occurring in no other sample are excluded. Larger "
             "values are more permissive. Must be > 0. Defaults to %(default)s.")
         
-        params_grp.add_argument("--min-coverage", "-c", type=int, default=10, 
+        params_grp.add_argument("--min-coverage", "-c", type=int, default=10,
             help="Minimum coverage needed for a site to be included. Sites with lower \
 coverage are represented as N in the multi-sequence alignment. Defaults to %(default)s.")
-        
+
+        params_grp.add_argument("--exclude", action="store_true", default=False,
+            help="Instead of removing sample-private (non-core) SNPs from samples with an "
+            "abnormally low maximum ANI to all other samples, remove those samples "
+            "entirely from the merged output VCF. Defaults to %(default)s.")
+
     def run(
         self,
         input: List[File],
@@ -49,20 +58,24 @@ coverage are represented as N in the multi-sequence alignment. Defaults to %(def
         tmp_dir: Directory,
         alpha: float,
         min_coverage: int,
+        exclude: bool,
+        exclude_log: Union[File, None],
         **kwargs
     ):
-        
+
         print(
             f"Merging VCFs {', '.join([str(x) for x in input])} "
-            f"(alpha={alpha}). Writing output to {str(output)}..."
+            f"(alpha={alpha}, exclude={exclude}). Writing output to {str(output)}..."
         )
-        
+
         Collection(
             vcfs = input,
             output = output,
             tmp_dir = tmp_dir,
             alpha = alpha,
-            min_coverage = min_coverage
+            min_coverage = min_coverage,
+            exclude = exclude,
+            exclude_log = exclude_log
         ).merge()
         
         logging.info("Done!")

--- a/cleansweep/collection.py
+++ b/cleansweep/collection.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import logging
 import subprocess
-from cleansweep.vcf import VCF, _VCF_HEADER, write_merged_vcf
+from cleansweep.vcf import VCF, _VCF_HEADER, write_merged_vcf, remove_vcf_header_samples
 from scipy.spatial.distance import pdist, squareform
 
 @dataclass
@@ -19,6 +19,8 @@ class Collection:
     tmp_dir: Directory
     alpha: float = 10.0
     min_coverage: int = 10
+    exclude: bool = False
+    exclude_log: Union[File, None] = None
 
     def __post_init__(self):
 
@@ -38,7 +40,12 @@ class Collection:
             raise ValueError(
                 f"Alpha must be greater than 0. Got {self.alpha}."
             )
-            
+
+        if self.exclude_log is not None and not self.exclude:
+            raise ValueError(
+                f"--exclude-log ({self.exclude_log}) was given without --exclude."
+            )
+
     def merge(self):
 
         gzvcfs = self.prepare_vcfs(
@@ -59,18 +66,32 @@ class Collection:
             output = self.tmp_dir.joinpath("merged.named.vcf")
         )
 
-        vcf = self.merged_vcf_consensus_filter(
+        vcf, excluded_samples = self.merged_vcf_consensus_filter(
             vcf = self.tmp_dir.joinpath("merged.named.vcf"),
-            alpha = self.alpha
+            alpha = self.alpha,
+            exclude = self.exclude
         )
+
+        header = VCF(
+            self.tmp_dir.joinpath("merged.named.vcf")
+        ).get_header()
+
+        if excluded_samples:
+            print(
+                f"Excluding {len(excluded_samples)} sample(s) from merged VCF: "
+                f"{', '.join(excluded_samples)}."
+            )
+            header = remove_vcf_header_samples(header, excluded_samples)
 
         write_merged_vcf(
             vcf = vcf,
             file = self.output,
-            header = VCF(
-                self.tmp_dir.joinpath("merged.named.vcf")
-            ).get_header()
+            header = header
         )
+
+        if self.exclude_log is not None:
+            with open(self.exclude_log, "w") as file:
+                file.write("\n".join(excluded_samples))
 
         #shutil.rmtree(self.tmp_dir)
     
@@ -193,8 +214,9 @@ class Collection:
     def merged_vcf_consensus_filter(
         self,
         vcf: File,
-        alpha: float = 10.0
-    ) -> pd.DataFrame:
+        alpha: float = 10.0,
+        exclude: bool = False
+    ) -> Tuple[pd.DataFrame, List[str]]:
         
         print("Applying consensus filter to merged VCF...")
         
@@ -261,7 +283,7 @@ class Collection:
         if len(max_ani_per_sample) < 2:
             # Single sample — no filtering possible
             vcf_df = vcf_df.assign(pos=vcf_df.pos.astype("Int64"))
-            return vcf_df
+            return vcf_df, []
 
         ani_median = float(np.median(max_ani_per_sample))
         ani_iqr = float(np.percentile(max_ani_per_sample, 75) - np.percentile(max_ani_per_sample, 25))
@@ -272,22 +294,49 @@ class Collection:
             f"threshold (median - {alpha}*IQR)={threshold:.6f}"
         )
 
-        # Get core SNPs once — reused for every sample that triggers filtering
-        consensus, is_core = self.core_snps(genotype)
+        # Samples with a maximum ANI below the threshold
+        flagged_samples = [
+            sample_name
+            for sample_name in ani_matrix.index
+            if float(max_ani_per_sample.loc[sample_name]) < threshold
+        ]
 
-        print(
-            f"Found {is_core.sum()} core SNPs out of {len(is_core)} total SNPs "
-            f"({is_core.mean()*100:.2f}%)."
-        )
+        if exclude:
 
-        for sample_name in ani_matrix.index:
+            if flagged_samples and len(flagged_samples) == len(ani_matrix.index):
+                raise ValueError(
+                    f"All {len(ani_matrix.index)} samples were flagged as ANI outliers "
+                    f"(below threshold {threshold:.6f}); cannot exclude every sample "
+                    "from the merged VCF. Consider increasing --alpha."
+                )
 
-            # Highest ANI this sample shares with any other sample
-            max_ani = float(
-                max_ani_per_sample.loc[sample_name]
+            for sample_name in flagged_samples:
+
+                max_ani = float(max_ani_per_sample.loc[sample_name])
+
+                print(
+                    f"Sample {sample_name} has a maximum ANI of {max_ani:.6f} to any other "
+                    f"sample, below the threshold of {threshold:.6f} "
+                    f"(median={ani_median:.6f}, IQR={ani_iqr:.6f}, alpha={alpha}). "
+                    f"Excluding sample."
+                )
+
+            genotype = genotype.drop(columns=flagged_samples)
+            excluded_samples = flagged_samples
+
+        else:
+
+            # Get core SNPs once — reused for every sample that triggers filtering
+            consensus, is_core = self.core_snps(genotype)
+
+            print(
+                f"Found {is_core.sum()} core SNPs out of {len(is_core)} total SNPs "
+                f"({is_core.mean()*100:.2f}%)."
             )
 
-            if max_ani < threshold:
+            for sample_name in flagged_samples:
+
+                max_ani = float(max_ani_per_sample.loc[sample_name])
 
                 print(
                     f"Sample {sample_name} has a maximum ANI of {max_ani:.6f} to any other "
@@ -312,6 +361,12 @@ class Collection:
                     }
                 )
 
+            excluded_samples = []
+
+        remaining_columns = [
+            c for c in vcf_df.columns if c not in excluded_samples
+        ]
+
         vcf_df = genotype.join(
             vcf_df[
                 vcf_df.columns \
@@ -319,14 +374,14 @@ class Collection:
             ].set_index(
                 ["chrom", "pos"]
             )
-        ).reset_index()[vcf_df.columns]
+        ).reset_index()[remaining_columns]
 
         vcf_df = vcf_df.assign(
             pos = vcf_df.pos.astype("Int64")
         )
 
-        return vcf_df
-    
+        return vcf_df, excluded_samples
+
     def genome_lengths_from_vcf(
         self,
         vcf: File,

--- a/cleansweep/vcf.py
+++ b/cleansweep/vcf.py
@@ -262,6 +262,29 @@ def get_info_value(s:str, tag:str, delim:str = ";", dtype = float):
     except: 
         return None
 
+def remove_vcf_header_samples(header: str, samples: List[str]) -> str:
+    """Removes the given sample columns from the #CHROM line of a raw VCF header string.
+
+    Args:
+        header (str): Raw VCF header, as returned by VCF.get_header().
+        samples (List[str]): Sample names to remove from the #CHROM line.
+
+    Returns:
+        str: Header with the given samples removed from the #CHROM line.
+    """
+
+    if not samples:
+        return header
+
+    lines = header.split("\n")
+    chrom_idx = next(i for i, line in enumerate(lines) if line.startswith("#CHROM"))
+
+    lines[chrom_idx] = "\t".join(
+        f for f in lines[chrom_idx].split("\t") if f not in samples
+    )
+
+    return "\n".join(lines)
+
 def format_vcf_header(
     header: str,
     chrom: Union[None, str, List] = None,
@@ -297,10 +320,10 @@ def format_vcf_header(
             "##FILTER=<ID=LowAltBC,Description=\"Alternate allele depth is too low\">",
             "##FILTER=<ID=LowCov,Description=\"Coverage is too low\">",
             "##INFO=<ID=BC,Number=4,Type=Integer,Description=\"Base counts\">",
-            "##INFO=<ID=ORGFILT,Number=1,Type=String,Description=\"Original FILTER flag in the input VCF\">",
             "##INFO=<ID=CSP,Number=1,Type=Integer,Description=\"CleanSweep likelihood ratio for a variant being present in the query strain, log transformed\">",
             "##INFO=<ID=RD,Number=1,Type=Integer,Description=\"Reference allele base count\">",
             "##INFO=<ID=AD,Number=1,Type=Integer,Description=\"Main alternate allele base count\">",
+            "##INFO=<ID=PILON,Number=1,Type=String,Description=\"Original Pilon/variant caller FILTER flag\">"
         ]
         if add_filters
         else []

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -14,3 +14,4 @@ dependencies:
   - biopython
   - pytest
   - pytest-timeout
+  - scikit-learn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,3 +182,73 @@ def synthetic_collection_vcfs(session_tmpdir):
         vcfs.append(vcf_path)
 
     return tuple(vcfs)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic multi-sample VCFs with one ANI outlier, for --exclude tests
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def synthetic_collection_vcfs_with_outlier(session_tmpdir):
+    """
+    Three bgzipped, CSI-indexed single-sample VCFs for `cleansweep collection`.
+
+    sampleA and sampleB share identical genotypes at every site (ANI 1.0 to
+    each other). sampleC has an inverted genotype at most sites, giving it a
+    much lower ANI to both — it should be flagged as an outlier by the
+    ANI-based filter at low --alpha values.
+
+    Returns: tuple[Path, Path, Path] (sampleA, sampleB, sampleC)
+    """
+    rng = np.random.default_rng(11)
+    variant_positions = sorted(
+        rng.choice(range(200, CHROM_LEN - 200), size=20, replace=False)
+    )
+
+    genotypes = {
+        "sampleA": [1] * 20,
+        "sampleB": [1] * 20,
+        "sampleC": [0] * 18 + [1, 1],
+    }
+
+    vcfs = []
+    for sample_name, gts in genotypes.items():
+        vcf_path = session_tmpdir / f"{sample_name}.outlier.vcf.gz"
+
+        header = pysam.VariantHeader()
+        header.add_line("##fileformat=VCFv4.2")
+        header.add_line(f"##contig=<ID={CHROM},length={CHROM_LEN}>")
+        header.add_line('##INFO=<ID=DP,Number=1,Type=Integer,Description="Total depth">')
+        header.add_line(
+            '##INFO=<ID=BC,Number=4,Type=Integer,'
+            'Description="Base counts A,C,G,T">'
+        )
+        header.add_line('##INFO=<ID=MQ,Number=1,Type=Integer,Description="Mean mapping quality">')
+        header.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+        header.add_sample(sample_name)
+
+        with pysam.VariantFile(vcf_path, "wz", header=header) as vf:
+            for pos, gt in zip(variant_positions, gts):
+                dp = 60
+                alt_bc = 45 if gt == 1 else 5
+                ref_bc = dp - alt_bc
+
+                rec = vf.new_record()
+                rec.chrom = CHROM
+                rec.pos = pos
+                rec.ref = "A"
+                rec.alts = ("T",)
+                rec.qual = 60
+                rec.info["DP"] = dp
+                rec.info["BC"] = (ref_bc, 0, alt_bc, 0)
+                rec.info["MQ"] = 60
+                rec.samples[sample_name]["GT"] = (gt,)
+                vf.write(rec)
+
+        rc = subprocess.run(["bcftools", "index", str(vcf_path)], capture_output=True)
+        if rc.returncode != 0:
+            raise RuntimeError(
+                f"bcftools index failed for {vcf_path}: {rc.stderr.decode()}"
+            )
+        vcfs.append(vcf_path)
+
+    return tuple(vcfs)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,5 +1,18 @@
 """Integration tests for `cleansweep collection` CLI."""
 import subprocess
+from pathlib import Path
+
+
+def _chrom_line(vcf_path):
+    with open(vcf_path) as f:
+        for line in f:
+            if line.startswith("#CHROM"):
+                return line.rstrip("\n")
+    raise AssertionError(f"No #CHROM line found in {vcf_path}")
+
+
+def _sample_names(vcf_path):
+    return _chrom_line(vcf_path).split("\t")[9:]
 
 
 class TestCollectionCLI:
@@ -29,3 +42,87 @@ class TestCollectionCLI:
         subprocess.run(cmd, capture_output=True, check=True)
         assert output.exists()
         assert output.stat().st_size > 0
+
+
+class TestCollectionExcludeCLI:
+
+    _base_opts = ["--alpha", "1", "-c", "5"]
+
+    def test_exclude_removes_outlier_sample(
+        self, synthetic_collection_vcfs_with_outlier, tmp_path
+    ):
+        vcf_a, vcf_b, vcf_c = synthetic_collection_vcfs_with_outlier
+        name_a, name_b, name_c = (Path(v).stem for v in (vcf_a, vcf_b, vcf_c))
+        output = tmp_path / "merged.exclude.vcf"
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b), str(vcf_c),
+            "--output", str(output),
+            "--tmp-dir", str(tmp_path / "tmp"),
+            "--exclude",
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+        samples = _sample_names(output)
+        assert name_c not in samples
+        assert name_a in samples
+        assert name_b in samples
+
+        # Header sample count must match the data rows' column count, or the
+        # output VCF is malformed.
+        with open(output) as f:
+            data_line = next(line for line in f if not line.startswith("#"))
+        assert len(data_line.rstrip("\n").split("\t")) == len(_chrom_line(output).split("\t"))
+
+    def test_without_exclude_keeps_all_samples(
+        self, synthetic_collection_vcfs_with_outlier, tmp_path
+    ):
+        vcf_a, vcf_b, vcf_c = synthetic_collection_vcfs_with_outlier
+        expected = {Path(v).stem for v in (vcf_a, vcf_b, vcf_c)}
+        output = tmp_path / "merged.noexclude.vcf"
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b), str(vcf_c),
+            "--output", str(output),
+            "--tmp-dir", str(tmp_path / "tmp2"),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+        samples = _sample_names(output)
+        assert set(samples) == expected
+
+    def test_exclude_log_records_excluded_sample(
+        self, synthetic_collection_vcfs_with_outlier, tmp_path
+    ):
+        vcf_a, vcf_b, vcf_c = synthetic_collection_vcfs_with_outlier
+        name_c = Path(vcf_c).stem
+        exclude_log = tmp_path / "excluded.txt"
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b), str(vcf_c),
+            "--output", str(tmp_path / "merged.log.vcf"),
+            "--tmp-dir", str(tmp_path / "tmp3"),
+            "--exclude",
+            "--exclude-log", str(exclude_log),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+        assert exclude_log.exists()
+        assert exclude_log.read_text().splitlines() == [name_c]
+
+    def test_exclude_log_without_exclude_flag_fails(
+        self, synthetic_collection_vcfs_with_outlier, tmp_path
+    ):
+        vcf_a, vcf_b, vcf_c = synthetic_collection_vcfs_with_outlier
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b), str(vcf_c),
+            "--output", str(tmp_path / "merged.bad.vcf"),
+            "--tmp-dir", str(tmp_path / "tmp4"),
+            "--exclude-log", str(tmp_path / "excluded_bad.txt"),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode != 0

--- a/tests/test_collection_logic.py
+++ b/tests/test_collection_logic.py
@@ -1,6 +1,7 @@
 """Unit tests for Collection logic — pandas DataFrames only, no file I/O."""
 import numpy as np
 import pandas as pd
+import pysam
 import pytest
 
 from cleansweep.collection import Collection
@@ -20,6 +21,79 @@ def col(tmp_path_factory):
         tmp_dir=d / "tmp",
         alpha=10.0,
     )
+
+
+@pytest.fixture(scope="module")
+def merged_vcf_with_outlier(tmp_path_factory):
+    """
+    A small, already-merged multi-sample VCF — the shape `merged_vcf_consensus_filter`
+    receives in production (post bcftools-merge/reheader). sampleA and sampleB share
+    identical genotypes at every site; sampleC is inverted at most sites, giving it a
+    much lower ANI to both, so it gets flagged as an outlier at low alpha values.
+    """
+    d = tmp_path_factory.mktemp("merged_outlier")
+    vcf_path = d / "merged.named.vcf"
+
+    chrom = "NZ_SYNTHETIC01.1"
+    n_sites = 20
+
+    header = pysam.VariantHeader()
+    header.add_line("##fileformat=VCFv4.2")
+    header.add_line(f"##contig=<ID={chrom},length=20000>")
+    header.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+    for sample_name in ("sampleA", "sampleB", "sampleC"):
+        header.add_sample(sample_name)
+
+    genotypes = {
+        "sampleA": [1] * n_sites,
+        "sampleB": [1] * n_sites,
+        "sampleC": [0] * (n_sites - 2) + [1, 1],
+    }
+
+    with pysam.VariantFile(vcf_path, "w", header=header) as vf:
+        for i in range(n_sites):
+            rec = vf.new_record()
+            rec.chrom = chrom
+            rec.pos = 100 + i * 50
+            rec.ref = "A"
+            rec.alts = ("T",)
+            rec.qual = 60
+            for sample_name in ("sampleA", "sampleB", "sampleC"):
+                rec.samples[sample_name]["GT"] = (genotypes[sample_name][i],)
+            vf.write(rec)
+
+    return vcf_path
+
+
+class TestExcludeFlag:
+
+    def test_exclude_drops_outlier_sample_column(self, col, merged_vcf_with_outlier):
+        vcf_df, excluded = col.merged_vcf_consensus_filter(
+            vcf=merged_vcf_with_outlier, alpha=1.0, exclude=True
+        )
+        assert excluded == ["sampleC"]
+        assert "sampleC" not in vcf_df.columns
+        assert "sampleA" in vcf_df.columns
+        assert "sampleB" in vcf_df.columns
+
+    def test_without_exclude_keeps_outlier_sample_column(self, col, merged_vcf_with_outlier):
+        vcf_df, excluded = col.merged_vcf_consensus_filter(
+            vcf=merged_vcf_with_outlier, alpha=1.0, exclude=False
+        )
+        assert excluded == []
+        assert "sampleC" in vcf_df.columns
+
+    def test_exclude_log_without_exclude_raises(self, tmp_path_factory):
+        d = tmp_path_factory.mktemp("bad_exclude_log")
+        vcf_a = d / "a.vcf"
+        vcf_a.touch()
+        with pytest.raises(ValueError):
+            Collection(
+                vcfs=[vcf_a],
+                output=d / "out.vcf",
+                tmp_dir=d / "tmp",
+                exclude_log=d / "excluded.txt",
+            )
 
 
 class TestSnpDistance:


### PR DESCRIPTION
This pull request adds the ability to exclude outlier samples from merged VCFs in the `cleansweep collection` workflow, along with logging of excluded samples and corresponding documentation and test updates. It also introduces several improvements to argument handling, VCF header management, and test coverage for the new functionality.

**New Outlier Exclusion Feature:**

* Added an `--exclude` option to `cleansweep collection` that, when set, removes samples flagged as ANI outliers from the merged VCF instead of cleaning their sample-private variants. An optional `--exclude-log` argument allows writing excluded sample IDs to a file.

* Updated the documentation to describe the new `--exclude` and `--exclude-log` options, how outlier detection works, and example usage (`README.md`).

* Added the `remove_vcf_header_samples` function to ensure excluded samples are properly removed from the VCF header's `#CHROM` line (`cleansweep/vcf.py`).

* Improved header formatting and filter descriptions, including a fix for the `PILON` INFO field (`cleansweep/vcf.py`).

**Testing Enhancements:**

* Added a synthetic fixture generating a multi-sample VCF with one ANI outlier, and new test helpers for extracting sample names from VCFs, to support testing of the exclusion feature (`tests/conftest.py`, `tests/test_collection.py`).

**Dependency Update:**

* Added `scikit-learn` to the CI environment dependencies for enhanced testing or analysis support (`environment-ci.yml`).