### PR TITLE
Add documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,11 +14,11 @@ build:
 sphinx:
    configuration: docs/conf.py
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: requirements.txt
+# Python requirements required to build documentation
+python:
+   install:
+   - requirements: docs/requirements.txt
+   - method: pip
+     path: .
         
   

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,42 @@
+API Reference
+=============
+
+collection
+----------
+
+.. automodule:: cleansweep.collection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+filter
+------
+
+.. automodule:: cleansweep.filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+align
+-----
+
+.. automodule:: cleansweep.align
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vcf
+---
+
+.. automodule:: cleansweep.vcf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+io
+--
+
+.. automodule:: cleansweep.io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,11 @@
+project = "CleanSweep"
+author = "Marco Teixeira"
+release = "1.0.0"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+]
+
+html_theme = "sphinx_rtd_theme"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,16 @@
+CleanSweep
+==========
+
+Finds strain-specific single nucleotide variants from plate swipe data.
+
+CleanSweep leverages allele coverage depths to call strain-specific
+single-nucleotide variants from short-read plate swipe data. It calls variants
+along the entire genome of target strains, allowing genetic distances to be
+estimated using a common reference across samples.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   usage
+   api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==8.2.3
+sphinx-rtd-theme==3.0.2

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,95 @@
+Usage
+=====
+
+Input data
+----------
+
+Before calling variants with CleanSweep, you need strain-detection results
+(e.g. from StrainGE). You will need:
+
+- FASTQ files with plate swipe reads for alignment.
+- A set of reference sequences (FASTA), one per detected strain.
+
+CleanSweep calls variants for one strain at a time, so one detected strain
+should be designated as the target.
+
+Preparing a reference
+---------------------
+
+.. code-block:: bash
+
+   cleansweep prepare \
+       target_strain.fa \
+       --background other_strain_1.fa other_strain_2.fa \
+       --output output/directory/ \
+       --min-identity 0.95 \
+       --min-length 150
+
+This produces ``cleansweep.prepare.swp`` and ``cleansweep.reference.fa`` in
+the output directory. Set ``--min-length`` to the insert size.
+
+Aligning reads
+--------------
+
+.. code-block:: bash
+
+   cleansweep align \
+       reads1.fq \
+       reads2.fq \
+       --reference cleansweep.reference.fa \
+       --output cleansweep.alignment.bam
+
+Calling variants
+----------------
+
+Call variants with Pilon:
+
+.. code-block:: bash
+
+   pilon \
+       --genome cleansweep.reference.fa \
+       --frags cleansweep.alignment.bam \
+       --output samplename \
+       --outdir pilon \
+       --changes --vcf --fix bases --nostrays --duplicates
+
+   bcftools view pilon/samplename.vcf -o pilon/samplename.vcf.gz -O z
+   bcftools index pilon/samplename.vcf.gz
+
+Filtering SNVs
+--------------
+
+.. code-block:: bash
+
+   cleansweep filter \
+       pilon/samplename.vcf.gz \
+       cleansweep.prepare.swp \
+       cleansweep \
+       --min-depth 10 \
+       --threads 5
+
+SNVs present in the target strain will have ``PASS`` in the ``FILTER`` field
+of the output VCF.
+
+Building a collection MSA
+--------------------------
+
+After running ``cleansweep filter`` on multiple plate swipes, build a multiple
+sequence alignment with ``cleansweep collection``:
+
+.. code-block:: bash
+
+   cleansweep collection \
+       sample1/cleansweep.variants.vcf.gz \
+       sample2/cleansweep.variants.vcf.gz \
+       sample3/cleansweep.variants.vcf.gz \
+       --output collection.fasta \
+       --alpha 10 \
+       --min-coverage 10
+
+Use ``--exclude`` to remove divergent samples from the MSA instead of
+cleaning their private SNPs:
+
+.. code-block:: bash
+
+   cleansweep collection ... --exclude --exclude-log excluded_samples.txt


### PR DESCRIPTION
This pull request adds comprehensive documentation for the CleanSweep project, including configuration for Read the Docs, installation requirements, and detailed usage and API documentation. The changes enable automated documentation builds and provide clear guidance for users on installation, usage, and API reference.

**Documentation infrastructure:**
* Added `.readthedocs.yaml` configuration to specify build process, including Python requirements and pip installation, to support reproducible documentation builds.
* Added `docs/requirements.txt` with `sphinx` and `sphinx-rtd-theme` as dependencies for building the documentation.
* Created `docs/conf.py` with Sphinx project metadata and extensions for autodoc and napoleon, and set the HTML theme.

**User and API documentation:**
* Added `docs/index.rst` with an overview of CleanSweep and a table of contents linking to usage and API documentation.
* Added `docs/usage.rst` with step-by-step instructions and command-line examples for preparing references, aligning reads, calling variants, filtering SNVs, and building a multiple sequence alignment.
* Added `docs/api.rst` with an API reference, using autodoc to document the main modules (`collection`, `filter`, `align`, `vcf`, `io`).