### PR TITLE
Improve efficiency for the collection module

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,19 @@ cleansweep collection \
     sample2/cleansweep.variants.vcf.gz \
     sample3/cleansweep.variants.vcf.gz \
     --output collection.fasta \
+    --reference cleansweep.reference.fa \
     --alpha 10 \
     --min-coverage 10
 ```
 
+**Pass `--reference` for large collections.** Given the reference FASTA used for variant calling (the `cleansweep.reference.fa` written by `cleansweep prepare`), CleanSweep reads only the variant and low-coverage records from each VCF and patches them into a copy of the reference, instead of walking every record of every VCF. Every stage then scales with the number of variant sites rather than with the genome length, which is what makes hundreds of samples practical — around 90x faster on a whole-site VCF, with identical output.
+
+`--reference` is optional and accepts gzip-compressed FASTA. Without it, each VCF is converted to a full-length sequence and positions with no record at all are left as `N`. With it, the alignment spans the whole reference and positions with no record take the reference base — this is the intended behaviour, but it means the two modes differ for VCFs that do not contain every site (as produced by `cleansweep filter --variants`). For the default whole-site VCFs written by `cleansweep filter`, both modes give the same alignment.
+
 **How the outlier filter works:**
 
-1. Each per-sample VCF is converted to a nucleotide sequence. Positions with coverage below `--min-coverage` are encoded as `N`.
-2. For each sample, CleanSweep computes the maximum ANI to any other sample in the dataset, producing one value per sample.
+1. Each per-sample VCF is converted to a nucleotide sequence. Positions with coverage below `--min-coverage` are encoded as `N`, as are indels and multi-allelic sites.
+2. For each sample, CleanSweep computes the maximum ANI to any other sample in the dataset, producing one value per sample. ANI is always taken over the full alignment length, so it does not depend on whether `--reference` was used.
 3. The median and interquartile range (IQR) of these per-sample maximum ANIs are computed.
 4. Any sample whose maximum ANI falls below `median - alpha × IQR` is flagged as a divergent outlier.
 5. By default, flagged samples are cleaned in place: their sample-private SNPs (positions differing from all other samples) are replaced with the per-site consensus base of the remaining samples.

--- a/cleansweep/cli/collection.py
+++ b/cleansweep/cli/collection.py
@@ -33,6 +33,15 @@ class CollectionCmd(Subcommand):
 
         io_grp.add_argument("input", type=str, nargs="+", help="CleanSweep VCFs to merge.")
         io_grp.add_argument("--output", "-o", type=str, help="Output MSA file.")
+        io_grp.add_argument("--reference", "-r", type=str, default=None,
+            help="Reference FASTA used for variant calling (the cleansweep.reference.fa "
+            "written by cleansweep prepare), optionally gzip-compressed. Strongly "
+            "recommended: CleanSweep then only reads variant and low-coverage records "
+            "from each VCF and patches them into the reference, which is far faster and "
+            "uses far less memory for large collections. The MSA spans the whole "
+            "reference, so positions with no record in a VCF take the reference base. "
+            "Without it, each VCF is converted to a full-length sequence and positions "
+            "with no record are left as N. Defaults to no reference.")
         io_grp.add_argument("--exclude-log", type=str, default=None,
             help="Path to write the IDs of samples excluded from the MSA (one "
             "per line). Only meaningful together with --exclude; raises an error if "
@@ -71,6 +80,7 @@ coverage are represented as N in the multi-sequence alignment. Defaults to %(def
         exclude: bool,
         exclude_log: Union[File, None],
         n_threads: int,
+        reference: Union[File, None] = None,
         **kwargs
     ):
 
@@ -79,9 +89,19 @@ coverage are represented as N in the multi-sequence alignment. Defaults to %(def
             f"(alpha={alpha}, exclude={exclude}). Writing output to {str(output)}..."
         )
 
+        if reference is None:
+            print(
+                "No --reference given, so each VCF will be converted to a full-length "
+                "sequence. Pass the reference FASTA used for variant calling for a "
+                "much faster run on large collections."
+            )
+        else:
+            print(f"Anchoring the MSA on the reference in {str(reference)}...")
+
         Collection(
             vcfs=input,
             output=output,
+            reference=reference,
             alpha=alpha,
             min_coverage=min_coverage,
             exclude=exclude,

--- a/cleansweep/collection.py
+++ b/cleansweep/collection.py
@@ -1,24 +1,427 @@
 #%%
-import shutil
-import warnings
-import numpy as np
-import pandas as pd 
-from cleansweep.typing import File, Directory
-from typing import List, Tuple, Union
-from dataclasses import dataclass
-from pathlib import Path
+"""
+Builds a multiple sequence alignment from a collection of CleanSweep VCFs.
+
+The alignment is carried internally as a ``samples x positions`` array of base
+codes rather than as full-length strings. When a reference FASTA is supplied,
+only positions that resolve to something other than the reference base in at
+least one sample are held in that array, which keeps every stage of the
+pipeline proportional to the number of variant and low-coverage sites instead
+of to the genome length.
+
+Author: Marco Teixeira
+Email: mcarvalh@broadinstitute.org
+"""
+import gzip
 import logging
-import subprocess
-from cleansweep.vcf import VCF, _VCF_HEADER, IUPAC_CODES, write_merged_vcf, remove_vcf_header_samples
-from scipy.spatial.distance import pdist, squareform, hamming
+import warnings
+from dataclasses import dataclass
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from Bio import SeqIO
+
+from cleansweep.typing import File
+from cleansweep.vcf import IUPAC_CODES, VCF, get_info_value
+
+# Bases are held as ASCII byte codes, so the alignment costs one byte per cell.
+_N_CODE = np.uint8(ord("N"))
+_MISSING_CODE = np.uint8(ord("."))
+_IGNORED_CODES = (_N_CODE, _MISSING_CODE)
+
+# IUPAC ambiguity codes as byte values, keyed by the sorted constituent bases.
+_IUPAC_CODE_BYTES = {k: np.uint8(ord(v)) for k, v in IUPAC_CODES.items()}
+
+_QUERY_COLUMNS = ["chrom", "pos", "ref", "alt", "dp", "gt"]
+
+
+def open_fasta(file: File, mode: str = "r"):
+    """
+    Open a FASTA file, transparently handling gzip compression.
+
+    Parameters
+    ----------
+    file : File
+        Path to the FASTA file. Treated as gzip-compressed if it ends in ".gz".
+    mode : str, optional
+        Mode to open the file in. Default is "r".
+    """
+    if str(file).endswith(".gz"):
+        return gzip.open(file, mode=mode + "t")
+
+    return open(file, mode=mode)
+
+
+def load_reference(
+    reference: File
+) -> Tuple[np.ndarray, Dict[str, int], Dict[str, int]]:
+    """
+    Read a reference FASTA into a flat array of base codes.
+
+    Contigs are concatenated in the order they appear in the file, so a VCF
+    record maps to the array index ``offsets[chrom] + pos - 1``.
+
+    Parameters
+    ----------
+    reference : File
+        Path to the reference FASTA, optionally gzip-compressed.
+
+    Returns
+    -------
+    tuple
+        The concatenated sequence as an array of base codes, a mapping of contig
+        name to its start index in that array, and a mapping of contig name to
+        its length.
+    """
+    chunks, offsets, lengths, cursor = [], {}, {}, 0
+
+    with open_fasta(reference) as handle:
+        for record in SeqIO.parse(handle, "fasta"):
+
+            if record.id in offsets:
+                raise ValueError(
+                    f"Reference FASTA {str(reference)} has more than one contig named "
+                    f"{record.id}."
+                )
+
+            sequence = np.frombuffer(
+                str(record.seq).upper().encode("ascii"), dtype=np.uint8
+            )
+
+            offsets[record.id] = cursor
+            lengths[record.id] = len(sequence)
+            cursor += len(sequence)
+            chunks.append(sequence)
+
+    if not chunks:
+        raise ValueError(f"Reference FASTA {str(reference)} has no sequences.")
+
+    return np.concatenate(chunks), offsets, lengths
+
+
+def include_expression(min_dp: int) -> str:
+    """
+    Build the bcftools expression selecting the records that need to be read.
+
+    Any record that could resolve to something other than the reference base is
+    matched: alternate and missing genotypes, sites below the coverage
+    threshold, sites with no depth annotation, indels, and multi-allelic sites.
+    Records that do not match are single-base reference calls with adequate
+    coverage, and the alignment already holds the reference base for those.
+
+    The expression is deliberately permissive - it selects a superset and
+    `resolve_bases` does the authoritative classification - because a record
+    wrongly skipped here would silently become a reference base.
+
+    Parameters
+    ----------
+    min_dp : int
+        Minimum depth of coverage for a genotype call to be trusted.
+    """
+    return (
+        f'GT="alt" || GT="mis" || INFO/DP<{int(min_dp)} || INFO/DP="." '
+        '|| strlen(REF)!=1 || strlen(ALT)!=1 || N_ALT>1'
+    )
+
+
+def vcf_samples(vcf: File) -> List[str]:
+    """
+    Return the sample names declared in the header of a VCF.
+
+    Parameters
+    ----------
+    vcf : File
+        Path to the VCF file, optionally compressed.
+    """
+    header = VCF(vcf).get_header()
+    for line in header.splitlines():
+        if line.startswith("#CHROM"):
+            return line.split("\t")[9:]
+    return []
+
+
+def _normalize_vcf_df(vcf_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Map ``VCF.read()`` output to the ``chrom/pos/ref/alt/dp/gt`` format.
+
+    The sample column is always the last column in the DataFrame; its name
+    depends on what the VCF header declares.  The GT value is the first
+    colon-separated field of the sample cell (in case FORMAT has more fields).
+    The DP value is extracted from the INFO string.
+    """
+    sample_col = vcf_df.columns[-1]
+    gt = vcf_df[sample_col].astype(str).str.split(":").str[0]
+    dp = vcf_df["info"].apply(lambda x: get_info_value(x, "DP", dtype=str))
+    return pd.DataFrame({
+        "chrom": vcf_df["chrom"].values,
+        "pos": vcf_df["pos"].values,
+        "ref": vcf_df["ref"].values,
+        "alt": vcf_df["alt"].values,
+        "dp": dp.values,
+        "gt": gt.values,
+    })
+
+def read_sparse_vcf(vcf: File, min_dp: int = 10) -> pd.DataFrame:
+    """
+    Read the records of a VCF that do not resolve to the reference base.
+
+    Filtering happens inside bcftools, so only the selected records are ever
+    decoded into Python.
+
+    Parameters
+    ----------
+    vcf : File
+        Path to the VCF file, optionally compressed.
+    min_dp : int, optional
+        Minimum depth of coverage for a genotype call to be trusted.
+        Default is 10.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per selected record, with columns chrom, pos, ref, alt, dp and
+        gt. Empty if no record was selected.
+    """
+    samples = vcf_samples(vcf)
+
+    if len(samples) != 1:
+        raise ValueError(
+            f"Expected exactly one sample per VCF, but {str(vcf)} has {len(samples)}"
+            + (f" ({', '.join(samples)})" if samples else "")
+            + ". CleanSweep collection takes one single-sample VCF per plate swipe."
+        )
+
+    vcf_df = VCF(vcf).read(
+        chrom=None,
+        include=[include_expression(min_dp)],
+        add_base_counts=False,
+        filter_indels=False,
+    )
+
+    if vcf_df.empty:
+        return pd.DataFrame(columns=_QUERY_COLUMNS)
+
+    return _normalize_vcf_df(vcf_df)
+
+
+def read_reference_calls(
+    vcf: File,
+    min_dp: int = 10
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Read the records of a VCF that do resolve to the reference base.
+
+    This is the complement of `read_sparse_vcf`, and is only needed on the
+    reference-free path, where the reference bases have to come from the REF
+    column of the VCF itself.
+
+    A record on which the expression cannot be evaluated at all - one with no
+    FORMAT/GT field, say - satisfies neither the include nor the exclude form,
+    so it appears in neither result and is left as "N". That matches how the
+    row-wise implementation treated records it could not classify.
+
+    Parameters
+    ----------
+    vcf : File
+        Path to the VCF file, optionally compressed.
+    min_dp : int, optional
+        Minimum depth of coverage for a genotype call to be trusted.
+        Default is 10.
+
+    Returns
+    -------
+    tuple
+        Positions of the reference calls and their base codes.
+    """
+    vcf_df = VCF(vcf).read(
+        chrom=None,
+        exclude=[include_expression(min_dp)],
+        add_base_counts=False,
+        filter_indels=False,
+    )
+
+    if vcf_df.empty:
+        return np.empty(0, dtype=np.int64), np.empty(0, dtype=np.uint8)
+
+    return vcf_df["pos"].to_numpy(dtype=np.int64), first_base_codes(vcf_df["ref"])
+
+
+def first_base_codes(values: pd.Series) -> np.ndarray:
+    """
+    Return the base code of the first character of every string in a Series.
+
+    Parameters
+    ----------
+    values : pd.Series
+        Series of allele strings.
+    """
+    # The trailing fillna catches empty strings, which str[0] turns into NaN.
+    first = values.fillna("N").astype(str).str.upper().str[0].fillna("N")
+
+    return np.frombuffer(first.to_numpy(dtype="S1").tobytes(), dtype=np.uint8)
+
+
+def resolve_bases(vcf_df: pd.DataFrame, min_dp: int = 10) -> np.ndarray:
+    """
+    Map each VCF record to the single base it contributes to the alignment.
+
+    Precedence, matching the row-wise implementation this replaces:
+
+    - depth below `min_dp`, or no depth annotation, becomes "N"
+    - a missing genotype becomes "N"
+    - an indel or multi-allelic site becomes "N"
+    - genotype 1 becomes the alternate allele
+    - genotype 0 becomes the reference allele
+    - anything else becomes "N"
+
+    Parameters
+    ----------
+    vcf_df : pd.DataFrame
+        Records as returned by `read_sparse_vcf`.
+    min_dp : int, optional
+        Minimum depth of coverage for a genotype call to be trusted.
+        Default is 10.
+
+    Returns
+    -------
+    np.ndarray
+        One base code per record.
+    """
+    reference_codes = first_base_codes(vcf_df["ref"])
+    alternate_codes = first_base_codes(vcf_df["alt"])
+
+    # A missing depth annotation coerces to NaN, which fails the comparison and
+    # so counts as insufficient coverage.
+    depth = pd.to_numeric(vcf_df["dp"], errors="coerce").to_numpy(dtype=float)
+    covered = depth >= min_dp
+
+    # Single-base REF and ALT only: indels and multi-allelic sites cannot be
+    # placed in a fixed-width alignment.
+    is_snv = (
+        vcf_df["ref"].fillna("").astype(str).str.len().eq(1)
+        & vcf_df["alt"].fillna("").astype(str).str.len().eq(1)
+    ).to_numpy()
+
+    genotype = vcf_df["gt"].fillna(".").astype(str)
+    usable = is_snv & covered
+
+    return np.where(
+        usable & genotype.eq("1").to_numpy(),
+        alternate_codes,
+        np.where(usable & genotype.eq("0").to_numpy(), reference_codes, _N_CODE),
+    ).astype(np.uint8)
+
+
+def combine_duplicates(
+    positions: np.ndarray,
+    codes: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Collapse records sharing a position into a single base code.
+
+    Positions carrying more than one distinct base are represented with the
+    corresponding IUPAC ambiguity code. A position where any record is ambiguous
+    stays ambiguous.
+
+    Parameters
+    ----------
+    positions : np.ndarray
+        Alignment index of each record.
+    codes : np.ndarray
+        Base code of each record.
+
+    Returns
+    -------
+    tuple
+        Sorted unique positions and their combined base codes.
+    """
+    order = np.argsort(positions, kind="stable")
+    positions, codes = positions[order], codes[order]
+
+    unique, starts, counts = np.unique(
+        positions, return_index=True, return_counts=True
+    )
+
+    combined = codes[starts].copy()
+
+    # Only positions carrying more than one record need combining, which is rare.
+    for j in np.flatnonzero(counts > 1):
+        group = codes[starts[j]:starts[j] + counts[j]]
+
+        if np.isin(group, _IGNORED_CODES).any():
+            combined[j] = _N_CODE
+            continue
+
+        bases = "".join(sorted({chr(code) for code in group}))
+        combined[j] = _IUPAC_CODE_BYTES.get(bases, _N_CODE)
+
+    return unique, combined
+
+
+def pack_sequences(sequences: Iterable[str]) -> Tuple[np.ndarray, int]:
+    """
+    Pack sequences into an array of base codes, padding with "N".
+
+    Parameters
+    ----------
+    sequences : Iterable[str]
+        Nucleotide sequences, which need not be the same length.
+
+    Returns
+    -------
+    tuple
+        A ``sequences x length`` array of base codes and the alignment length.
+    """
+    sequences = list(sequences)
+
+    if not sequences:
+        return np.empty((0, 0), dtype=np.uint8), 0
+
+    length = max(len(sequence) for sequence in sequences)
+    matrix = np.full((len(sequences), length), _N_CODE, dtype=np.uint8)
+
+    for i, sequence in enumerate(sequences):
+        if sequence:
+            matrix[i, :len(sequence)] = np.frombuffer(
+                sequence.encode("ascii"), dtype=np.uint8
+            )
+
+    return matrix, length
+
+
+def sequences_to_matrix(
+    sequences: Dict[str, str]
+) -> Tuple[List[str], np.ndarray, int]:
+    """
+    Pack a mapping of sequences into an array of base codes.
+
+    Parameters
+    ----------
+    sequences : dict[str, str]
+        A mapping of sequence name to nucleotide sequence.
+
+    Returns
+    -------
+    tuple
+        The sequence names in insertion order, a ``names x length`` array of
+        base codes, and the alignment length.
+    """
+    names = list(sequences)
+    matrix, length = pack_sequences(sequences[name] for name in names)
+
+    return names, matrix, length
+
 
 @dataclass
 class Collection:
 
     vcfs: List[File]
     output: File
+    reference: Union[File, None] = None
     alpha: float = 10.0
     min_coverage: int = 10
     exclude: bool = False
@@ -33,48 +436,63 @@ class Collection:
             if not Path(vcf).exists():
                 raise FileNotFoundError(f"VCF {str(vcf)} not found.")
 
+        if self.reference is not None and not Path(self.reference).exists():
+            raise FileNotFoundError(f"Reference FASTA {str(self.reference)} not found.")
+
         if self.alpha <= 0:
             raise ValueError(f"Alpha must be greater than 0. Got {self.alpha}.")
 
         if self.exclude_log is not None and not self.exclude:
             raise ValueError(f"--exclude-log ({self.exclude_log}) was given without --exclude.")
-        
+
         self.__set_n_threads()
-    
+
     def msa(self):
         """
-        Converts a set of VCF files to a multiple sequence alignment (MSA) in FASTA 
-        format. Samples that are identified as outliers based on their pairwise 
-        similarities will be excluded from the MSA or have their private SNPs removed, 
+        Converts a set of VCF files to a multiple sequence alignment (MSA) in FASTA
+        format. Samples that are identified as outliers based on their pairwise
+        similarities will be excluded from the MSA or have their private SNPs removed,
         depending on the `exclude` parameter.
 
-        If `exclude` is False (default), this method looks for outlier samples: it 
+        If `exclude` is False (default), this method looks for outlier samples: it
         calculates the maximum average nucleotide identity (ANI) each sample shares with
         any other sample. If a sample's maximum ANI is below the threshold defined by
-        the median minus `alpha` times the interquartile range (IQR) of the maximum ANI 
-        values, it is considered an outlier. For each outlier sample, any SNPs that are 
+        the median minus `alpha` times the interquartile range (IQR) of the maximum ANI
+        values, it is considered an outlier. For each outlier sample, any SNPs that are
         not shared with at least one other sample (i.e., private SNPs) are removed.
 
         If `exclude` is True, outlier samples are completely excluded from the MSA.
+
+        If a reference FASTA was given, the alignment spans the whole reference and only
+        variant and low-coverage sites are held in memory. Otherwise each VCF is
+        converted to a full-length sequence, which is considerably slower and uses far
+        more memory for large collections.
         """
+        if self.reference is None:
+            logging.info(
+                "No reference FASTA given, so each VCF will be converted to a "
+                "full-length sequence. Pass a reference for a much faster run on "
+                "large collections."
+            )
+            names, matrix, positions, reference = self.__build_dense()
+        else:
+            names, matrix, positions, reference = self.__build_sparse()
 
-        # Convert each VCF to a sequence. Use multithreading to speed up the process
-        # if there are many VCFs.
-        with ThreadPool(processes=self.n_threads) as pool:
-            sequences = dict(pool.starmap(
-                self._vcf_to_seq_item, [(vcf,) for vcf in self.vcfs]
-            ))
+        if not names:
+            warnings.warn("No sequences to align. Writing an empty MSA.")
+            Path(self.output).write_text("")
+            return
 
-        # Pad sequences to the same length so downstream operations work correctly
-        if sequences:
-            max_len = max(len(s) for s in sequences.values())
-            sequences = {
-                name: seq + "N" * (max_len - len(seq))
-                for name, seq in sequences.items()
-            }
+        total_length = len(reference) if reference is not None else matrix.shape[1]
 
         # Find outliers
-        outliers = self.find_outliers(sequences=sequences, alpha=self.alpha)
+        outlier_indices = self.outlier_indices(
+            matrix=matrix,
+            total_length=total_length,
+            alpha=self.alpha,
+            n_threads=self.n_threads
+        )
+        outliers = [names[i] for i in outlier_indices]
 
         if self.exclude and outliers:
             logging.info(
@@ -82,11 +500,9 @@ class Collection:
                 f"{', '.join(outliers)}."
             )
 
-            sequences = {
-                name: seq
-                for name, seq in sequences.items()
-                if name not in outliers
-            }
+            keep = np.setdiff1d(np.arange(len(names)), outlier_indices)
+            names = [names[i] for i in keep]
+            matrix = matrix[keep]
 
             # Write a list of excluded samples to the exclude log file if specified
             if self.exclude_log is not None:
@@ -100,50 +516,164 @@ class Collection:
                 f"{', '.join(outliers)}. Removing sample-private SNPs..."
             )
 
-            if len(sequences) < 3:
+            if len(names) < 3:
                 warnings.warn(
                     "You are trying to use CleanSweep collection with less than 3 "
                     "sequences. This may result in unreliable SNP calls."
                 )
 
             # Generate consensus sequence
-            consensus = self.consensus_sequence(sequences=sequences)
+            consensus = self.consensus_from_matrix(matrix)
 
-            # Remove private SNPs from outliers. Use multithreading to speed up
-            # the process if there are many outliers.
-            with ThreadPool(processes=self.n_threads) as pool:
-                sequences = dict(pool.starmap(
-                    self._remove_private_snps_item,
-                    [(k, sequences, outliers, consensus) for k in sequences.keys()]
-                ))
+            # Remove private SNPs from every outlier, against the same consensus
+            for i in outlier_indices:
+                self.remove_private_from_matrix(
+                    matrix=matrix,
+                    row=i,
+                    consensus=consensus
+                )
 
         # Write MSA to output
-        self.write_msa(
-            sequences=sequences,
-            output_file=self.output
+        self.write_matrix(
+            names=names,
+            matrix=matrix,
+            positions=positions,
+            reference=reference
         )
-    
+
+    def __build_sparse(self):
+        """
+        Read every VCF into an alignment anchored on the reference.
+
+        Only positions that differ from the reference in at least one sample are
+        held, so the alignment array is proportional to the number of variant and
+        low-coverage sites rather than to the genome length.
+        """
+        reference, offsets, lengths = load_reference(self.reference)
+
+        with ThreadPool(processes=self.n_threads) as pool:
+            parsed = pool.starmap(
+                self._vcf_to_sparse_item,
+                [(vcf, offsets, lengths) for vcf in self.vcfs]
+            )
+
+        names = [name for name, _, _ in parsed]
+        indices = [index for _, index, _ in parsed]
+
+        populated = [index for index in indices if index.size]
+        positions = (
+            np.unique(np.concatenate(populated))
+            if populated
+            else np.empty(0, dtype=np.int64)
+        )
+
+        logging.info(
+            f"Found {positions.size} variant or low-coverage site(s) across "
+            f"{len(names)} sample(s) in a {len(reference)} bp reference."
+        )
+
+        # Seeding with the reference is what lets the untouched positions be left
+        # out: every sample holds the reference base there by definition.
+        matrix = np.tile(reference[positions], (len(names), 1))
+
+        for i, (_, index, codes) in enumerate(parsed):
+            if index.size:
+                matrix[i, np.searchsorted(positions, index)] = codes
+
+        return names, matrix, positions, reference
+
+    def __build_dense(self):
+        """Convert every VCF to a full-length sequence, without a reference."""
+        with ThreadPool(processes=self.n_threads) as pool:
+            sequences = dict(pool.starmap(
+                self._vcf_to_seq_item, [(vcf,) for vcf in self.vcfs]
+            ))
+
+        names, matrix, _ = sequences_to_matrix(sequences)
+
+        return names, matrix, None, None
+
+    def _vcf_to_sparse_item(self, vcf, offsets, lengths):
+        return (Path(vcf).stem,) + self.vcf_to_sparse(
+            vcf=vcf,
+            offsets=offsets,
+            lengths=lengths,
+            min_dp=self.min_coverage
+        )
+
     def _vcf_to_seq_item(self, vcf):
         return (Path(vcf).stem, self.vcf_to_seq(vcf=vcf, min_dp=self.min_coverage))
 
-    def _remove_private_snps_item(self, k, sequences, outliers, consensus):
-        if k in outliers:
-            return (k, self.remove_private_snps(
-                target_sequence=sequences[k],
-                other_sequences={name: seq for name, seq in sequences.items() if name != k},
-                consensus_sequence=consensus
-            ))
-        return (k, sequences[k])
+    def vcf_to_sparse(
+        self,
+        vcf: File,
+        offsets: Dict[str, int],
+        lengths: Dict[str, int],
+        min_dp: int = 10,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Convert a VCF to the positions and bases that differ from the reference.
+
+        Parameters
+        ----------
+        vcf : File
+            Path to the input VCF file.
+        offsets : dict[str, int]
+            Mapping of contig name to its start index in the reference array, as
+            returned by `load_reference`.
+        lengths : dict[str, int]
+            Mapping of contig name to its length, as returned by
+            `load_reference`.
+        min_dp : int, optional
+            Minimum depth of coverage to consider a genotype call valid.
+            Default is 10.
+
+        Returns
+        -------
+        tuple
+            Sorted alignment indices and their base codes.
+        """
+        vcf_df = read_sparse_vcf(vcf, min_dp=min_dp)
+
+        if vcf_df.empty:
+            return np.empty(0, dtype=np.int64), np.empty(0, dtype=np.uint8)
+
+        unknown = set(vcf_df["chrom"].unique()) - set(offsets)
+        if unknown:
+            raise ValueError(
+                f"VCF {str(vcf)} has records on contig(s) absent from the reference: "
+                f"{', '.join(sorted(unknown))}. The reference has "
+                f"{', '.join(sorted(offsets))}."
+            )
+
+        positions = vcf_df["pos"].to_numpy(dtype=np.int64)
+        contig_lengths = vcf_df["chrom"].map(lengths).to_numpy(dtype=np.int64)
+
+        outside = (positions < 1) | (positions > contig_lengths)
+        if outside.any():
+            record = vcf_df[outside].iloc[0]
+            raise ValueError(
+                f"VCF {str(vcf)} has a record at {record.chrom}:{record.pos}, outside "
+                f"the reference contig (1-{lengths[record.chrom]})."
+            )
+
+        indices = vcf_df["chrom"].map(offsets).to_numpy(dtype=np.int64) + positions - 1
+
+        return combine_duplicates(indices, resolve_bases(vcf_df, min_dp=min_dp))
 
     def vcf_to_seq(
         self,
         vcf: File,
         min_dp: int = 10,
-        gt_col: str = "sample",
-    ):
+    ) -> str:
         """
-        Convert a VCF file to a nucleotide sequence. Handles multi-allelic sites by 
+        Convert a VCF file to a nucleotide sequence. Handles multi-allelic sites by
         using IUPAC codes to represent the bases.
+
+        This is the reference-free path: the sequence runs from position 1 to the last
+        position in the VCF, and positions with no record at all are left as "N".
+        Genotypes are taken from the FORMAT/GT field. Prefer `vcf_to_sparse` when a
+        reference FASTA is available.
 
         Parameters
         ----------
@@ -151,234 +681,230 @@ class Collection:
             Path to the input VCF file.
         min_dp : int, optional
             Minimum depth of coverage to consider a genotype call valid. Default is 10.
-        gt_col : str, optional
-            Name of the genotype column in the VCF. Default is "sample".
-        
+
         Returns
         -------
         str
-            A string representing the nucleotide sequence, where each position 
+            A string representing the nucleotide sequence, where each position
             corresponds to a base in the reference genome.
         """
-        # Read input VCF
-        vcf_df = VCF(vcf).read(None)
+        variants = read_sparse_vcf(vcf, min_dp=min_dp)
+        reference_positions, reference_codes = read_reference_calls(vcf, min_dp=min_dp)
+
+        variant_positions, variant_codes = (
+            combine_duplicates(
+                variants["pos"].to_numpy(dtype=np.int64),
+                resolve_bases(variants, min_dp=min_dp)
+            )
+            if not variants.empty
+            else (np.empty(0, dtype=np.int64), np.empty(0, dtype=np.uint8))
+        )
+
+        # The two queries partition the VCF, so between them they see every record.
+        last_position = max(
+            int(variant_positions.max()) if variant_positions.size else 0,
+            int(reference_positions.max()) if reference_positions.size else 0,
+        )
 
         # Return an empty string if the VCF is empty
-        if vcf_df.empty:
+        if last_position == 0:
             return ""
 
-        # Auto-detect the sample column: it's the 10th column (index 9), after the
-        # 9 fixed VCF columns. Named sample columns won't match the "sample" default.
-        if gt_col not in vcf_df.columns:
-            gt_col = vcf_df.columns[9]
+        sequence = np.full(last_position, _N_CODE, dtype=np.uint8)
+        sequence[reference_positions - 1] = reference_codes
+        sequence[variant_positions - 1] = variant_codes
 
-        # Allocate an array to hold the sequence
-        last_pos = vcf_df.iloc[-1].pos
-        seq = np.array(["N"] * last_pos, dtype=str)
+        return sequence.tobytes().decode("ascii")
 
-        # Iterate through the VCF and fill in the sequence
-        # To handle multi-allelic sites, we will use IUPAC codes to represent the bases
-        # While parsing the same position, we will collect the bases in a string and 
-        # then convert to IUPAC code at the end
-        prev_pos, base = 1, ""
-
-        for i, row in vcf_df.iterrows():
-
-            # If the position has changed, update the sequence with the previous base
-            # Note that VCF positions are 1-based, so we subtract 1 to get the correct 
-            # index in the sequence array
-            if row.pos != prev_pos:
-                seq[prev_pos - 1] = IUPAC_CODES.get("".join(sorted(base)), "N")
-                base = ""
-                prev_pos = row.pos
-            
-            # Select between the ref or alt allele
-            if row.depth < min_dp or str(row[gt_col]) == ".":
-                base = "N"
-            elif str(row[gt_col]) == "0":
-                base += row.ref
-            elif str(row[gt_col]) == "1":
-                base += row.alt
-            else:
-                base = "N"
-
-        # Update the last position in the sequence with the last base
-        seq[last_pos - 1] = IUPAC_CODES.get("".join(sorted(base)), "N")
-
-        # Trim the sequence to the last position and return as a string
-        return "".join(seq[:last_pos])
-    
-    def find_outliers(
-        self,
-        sequences: dict[str, str],
-        alpha: float = 3.0
-    ):
+    @staticmethod
+    def max_identities(
+        matrix: np.ndarray,
+        total_length: int,
+        n_threads: int = 1
+    ) -> np.ndarray:
         """
-        Identify outliers in a set of sequences based on their pairwise similarities.
-        Outliers are defined as sequences whose minimum similarity to any other sequence
-        is below the threshold defined by the median minus `alpha` times the 
-        interquartile range (IQR).
+        Highest fraction of identical positions each row shares with any other row.
+
+        Only the columns present in `matrix` are compared, but the fraction is taken
+        over `total_length`. Any column left out of a reference-anchored alignment
+        holds the reference base in every sample and so contributes no differences,
+        which makes this exactly equal to a whole-genome Hamming identity.
 
         Parameters
         ----------
-        sequences : dict[str, str]
-            A dictionary where keys are sequence names and values are nucleotide 
-            sequences.
+        matrix : np.ndarray
+            A ``samples x positions`` array of base codes.
+        total_length : int
+            Length of the full alignment, used as the denominator.
+        n_threads : int, optional
+            Number of threads to compare rows with. Default is 1.
+
+        Returns
+        -------
+        np.ndarray
+            One maximum identity per row.
+        """
+        n_samples = matrix.shape[0]
+
+        if n_samples < 2 or total_length <= 0:
+            return np.ones(n_samples)
+
+        def min_differences(i: int) -> int:
+            differences = np.count_nonzero(matrix != matrix[i], axis=1)
+            # A row is trivially identical to itself, so rule it out.
+            differences[i] = np.iinfo(differences.dtype).max
+            return int(differences.min())
+
+        with ThreadPool(processes=n_threads) as pool:
+            minima = pool.map(min_differences, range(n_samples))
+
+        return 1.0 - np.asarray(minima, dtype=float) / float(total_length)
+
+    @classmethod
+    def outlier_indices(
+        cls,
+        matrix: np.ndarray,
+        total_length: int,
+        alpha: float = 3.0,
+        n_threads: int = 1
+    ) -> List[int]:
+        """
+        Identify rows whose maximum identity to any other row is an outlier.
+
+        Parameters
+        ----------
+        matrix : np.ndarray
+            A ``samples x positions`` array of base codes.
+        total_length : int
+            Length of the full alignment.
         alpha : float, optional
             The multiplier for the interquartile range (IQR) to determine outliers.
             Default is 3.0.
+        n_threads : int, optional
+            Number of threads to compare rows with. Default is 1.
 
         Returns
         -------
-        list[str]
-            A list of sequence names identified as outliers.
+        list[int]
+            Row indices identified as outliers.
         """
-
-        if len(sequences) < 2:
+        if matrix.shape[0] < 2 or total_length <= 0:
             return []
 
-        # Holds the minimum similarity for each sequence between itself
-        # and all other sequences
-        min_similarities = {}
-
-        for name_1, seq_1 in sequences.items():
-            min_similarities[name_1] = np.max(
-                [
-                    1 - hamming(list(seq_1), list(seq_2))
-                    for name_2, seq_2 in sequences.items()
-                    if name_1 != name_2
-                ]
-            )
-
-        # Calculate the median and IQR of the minimum similarities
-        median = np.median(list(min_similarities.values()))
-        q1 = np.percentile(list(min_similarities.values()), 25)
-        q3 = np.percentile(list(min_similarities.values()), 75)
-        iqr = q3 - q1
+        identities = cls.max_identities(
+            matrix=matrix,
+            total_length=total_length,
+            n_threads=n_threads
+        )
 
         # Identify outliers based on the IQR method
-        outliers = [k for k, v in min_similarities.items()
-            if v < (median - alpha * iqr)]
-        
-        return outliers
-    
-    def consensus_sequence(
-        self,
-        sequences: dict[str, str]
-    ) -> np.ndarray:
+        median = np.median(identities)
+        q1, q3 = np.percentile(identities, [25, 75])
+
+        return np.flatnonzero(identities < (median - alpha * (q3 - q1))).tolist()
+
+    @staticmethod
+    def consensus_from_matrix(matrix: np.ndarray) -> np.ndarray:
         """
-        Generate a consensus sequence from a set of sequences. The consensus at each 
-        position is determined by the most common base among the sequences.
+        Per-column most common base code, ignoring "N" and ".".
 
         Parameters
         ----------
-        sequences : dict[str, str]
-            A dictionary where keys are sequence names and values are nucleotide 
-            sequences.
+        matrix : np.ndarray
+            A ``samples x positions`` array of base codes.
 
         Returns
         -------
-        Numpy array
-            An array representing the consensus sequence, where each position 
-            corresponds to the most common base at that position across all sequences.
+        np.ndarray
+            One consensus base code per column. Columns with no unambiguous base
+            at all are "N".
         """
-
-        if len(sequences) == 0:
+        if matrix.shape[0] == 0:
             raise ValueError("No sequences provided for consensus generation.")
-        
-        def mode(line):
-            "A helper function to compute the mode of a list, ignoring '.' and 'N'."
-            bases = line[~np.isin(line, [".", "N"])]
-            if len(bases) == 0:
-                return "N"
-            values, counts = np.unique(bases, return_counts=True)
-            return values[np.argmax(counts)]
-        
-        seq_array = np.array([list(seq) for seq in sequences.values()])
-        consensus = np.apply_along_axis(mode, 0, seq_array)
+
+        consensus = np.full(matrix.shape[1], _N_CODE, dtype=np.uint8)
+        best = np.zeros(matrix.shape[1], dtype=np.int64)
+
+        # Ascending order plus a strict comparison below means a tie resolves to
+        # the lexicographically smallest base.
+        for code in sorted(
+            code for code in np.unique(matrix) if code not in _IGNORED_CODES
+        ):
+            counts = np.count_nonzero(matrix == code, axis=0)
+
+            better = counts > best
+            consensus[better] = code
+            best[better] = counts[better]
+
         return consensus
-    
-    def remove_private_snps(
-        self,
-        target_sequence: str,
-        other_sequences: dict[str, str],
-        consensus_sequence: np.ndarray
-    ) -> str:
+
+    @staticmethod
+    def remove_private_from_matrix(
+        matrix: np.ndarray,
+        row: int,
+        consensus: np.ndarray
+    ):
         """
-        Remove private SNPs from the target sequence by replacing them with the 
-        consensus sequence.
+        Replace the bases unique to one row with the consensus, in place.
+
+        A row compares equal to itself, so requiring every other row to differ is
+        the same as comparing against the matrix with that row dropped - without
+        having to copy it out.
 
         Parameters
         ----------
-        target_sequence : str
-            The nucleotide sequence from which private SNPs will be removed.
-        other_sequences : dict[str, str]
-            A dictionary of other sequences to compare against the target sequence.
-        consensus_sequence : np.ndarray
-            The consensus sequence to use for replacing private SNPs.
-
-        Returns
-        -------
-        str
-            The target sequence with private SNPs replaced by the consensus sequence.
+        matrix : np.ndarray
+            A ``samples x positions`` array of base codes, modified in place.
+        row : int
+            Index of the row to clean.
+        consensus : np.ndarray
+            Consensus base codes, as returned by `consensus_from_matrix`.
         """
+        n_samples = matrix.shape[0]
 
-        # Convert sequences to numpy arrays for efficient comparison
-        other_seqs = np.array([list(seq) for _, seq in other_sequences.items()])
-        target_seq = np.array(list(target_sequence))
+        if n_samples < 2:
+            return
 
-        private_snps = np.all(other_seqs != target_seq, axis=0)
+        private = np.count_nonzero(matrix != matrix[row], axis=0) == n_samples - 1
+        matrix[row, private] = consensus[private]
 
-        # Replace private SNPs in the target sequence with the consensus
-        target_seq[private_snps] = consensus_sequence[private_snps]
-
-        return "".join(target_seq)
-    
-    def write_msa(
+    def write_matrix(
         self,
-        sequences: dict[str, str],
-        output_file: File
+        names: List[str],
+        matrix: np.ndarray,
+        positions: Union[np.ndarray, None],
+        reference: Union[np.ndarray, None]
     ):
         """
-        Write a multiple sequence alignment (MSA) to a FASTA file.
+        Write an alignment held as an array of base codes to a FASTA file.
+
+        With a reference, each sequence is the reference with the alignment columns
+        patched into it, so only one full-length sequence is ever resident.
 
         Parameters
         ----------
-        sequences : dict[str, str]
-            A dictionary where keys are sequence names and values are nucleotide 
-            sequences.
-        output_file : File
-            Path to the output FASTA file.
+        names : list[str]
+            Sequence names, in the same order as the rows of `matrix`.
+        matrix : np.ndarray
+            A ``samples x positions`` array of base codes.
+        positions : np.ndarray or None
+            Indices of the alignment columns within the reference. None when
+            `matrix` already holds full-length sequences.
+        reference : np.ndarray or None
+            Reference base codes, or None for a reference-free alignment.
         """
+        with open(self.output, "wb") as f:
+            for i, name in enumerate(names):
 
-        # Verify that all sequences are of the same length
-        lengths = {len(seq) for seq in sequences.values()}
-        if len(lengths) > 1:
-            raise ValueError(
-                "All sequences must be of the same length to write an MSA. "
-                f"Found lengths: {lengths}."
-            )
-        
-        with open(output_file, "w") as f:
-            for name, seq in sequences.items():
-                f.write(f">{name}\n")
-                f.write(f"{seq}\n")
+                if reference is None:
+                    sequence = matrix[i]
+                else:
+                    sequence = reference.copy()
+                    sequence[positions] = matrix[i]
 
-    def __raise_run_error(
-        self,
-        message: str,
-        command: List[str],
-        rc
-    ):
-        
-        if rc.returncode != 0:
-            message = message + f" Got return code {rc.returncode}. Command: \'{' '.join(command)}\'."
-            print(message)
-            print("stout dump:")
-            print(rc.stdout)
-            raise RuntimeError(message)
-        else:
-            print("Command successful!")
+                f.write(b">" + str(name).encode("ascii") + b"\n")
+                f.write(sequence.tobytes())
+                f.write(b"\n")
 
     def __set_n_threads(self):
         if self.n_threads is None:

--- a/cleansweep/vcf.py
+++ b/cleansweep/vcf.py
@@ -44,12 +44,13 @@ class VCF:
         if isinstance(self.file, Path): self.file = str(self.file) 
 
     def read(
-        self, 
-        chrom: Union[str, None, List], 
-        filters: Union[Collection[str], None] = None, 
+        self,
+        chrom: Union[str, None, List],
+        filters: Union[Collection[str], None] = None,
         include: Union[str, None]=None,
         exclude: Union[str, None]=None,
-        add_base_counts: bool = True
+        add_base_counts: bool = True,
+        filter_indels: bool = True,
     ) -> pd.DataFrame:
         """Filters a VCF file (compressed or uncompressed) with bcftools. Requires bcftools.
 
@@ -79,36 +80,38 @@ code {rc.returncode}. Command: \'{' '.join(command)}\'."
             logging.error(rc.stdout)
             raise RuntimeError(msg)
         
-        # Store filtered VCF as an attribute
-        self.vcf = pd.read_csv(
-            StringIO(rc.stdout.decode("utf-8")), 
-            sep="\t", 
-            comment="#", 
-            header=None
-        )  
-
-        self.vcf.columns = [
-            x
-            for x in rc.stdout \
-                .decode("utf-8") \
-                .split("\n") 
-            if x.startswith("#")
+        # Derive column names from the last # header line before parsing data,
+        # so an all-header response (no data records) can still return a typed
+        # empty DataFrame rather than raising EmptyDataError.
+        raw_cols = [
+            x for x in rc.stdout.decode("utf-8").split("\n") if x.startswith("#")
         ][-1].split("\t")
-
-        self.vcf.columns = [
+        columns = [
             (
                 x.removeprefix("#").lower()
                 if x.removeprefix("#").lower() in _VCF_HEADER
                 else x.removeprefix("#")
-            ) for x in self.vcf.columns
+            ) for x in raw_cols
         ]
+
+        try:
+            self.vcf = pd.read_csv(
+                StringIO(rc.stdout.decode("utf-8")),
+                sep="\t",
+                comment="#",
+                header=None,
+            )
+            self.vcf.columns = columns
+        except pd.errors.EmptyDataError:
+            self.vcf = pd.DataFrame(columns=columns)
 
         # Keep variants in the query
         if chrom:
             if isinstance(chrom, str): chrom = [chrom]
             self.vcf = self.vcf[self.vcf.chrom.isin(chrom)]
 
-        self.vcf = self.exclude_indels(self.vcf)
+        if filter_indels:
+            self.vcf = self.exclude_indels(self.vcf)
         if add_base_counts:
             self.vcf = self.add_info_columns(self.vcf)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,6 +84,7 @@ sequence alignment with ``cleansweep collection``:
        sample2/cleansweep.variants.vcf.gz \
        sample3/cleansweep.variants.vcf.gz \
        --output collection.fasta \
+       --reference cleansweep.reference.fa \
        --alpha 10 \
        --min-coverage 10
 
@@ -93,3 +94,25 @@ cleaning their private SNPs:
 .. code-block:: bash
 
    cleansweep collection ... --exclude --exclude-log excluded_samples.txt
+
+Scaling to large collections
+----------------------------
+
+``--reference`` takes the reference FASTA used for variant calling — the
+``cleansweep.reference.fa`` written by ``cleansweep prepare`` — optionally
+gzip-compressed. Given it, CleanSweep reads only the variant and low-coverage
+records from each VCF and patches them into a copy of the reference, rather than
+walking every record of every VCF.
+
+The alignment is then carried as a ``samples x variant sites`` array, so the
+outlier scan, the consensus, and the private-SNP removal all scale with the
+number of variant sites instead of with the genome length. This is what makes
+collections of hundreds of samples practical; on a whole-site VCF it runs around
+90 times faster and produces identical output.
+
+Without ``--reference``, each VCF is converted to a full-length sequence and
+positions with no record at all are left as ``N``. With it, the alignment spans
+the whole reference and positions with no record take the reference base. For the
+whole-site VCFs ``cleansweep filter`` writes by default the two modes agree; for
+the sparse VCFs written by ``cleansweep filter --variants`` they do not, and the
+reference-anchored result is the intended one.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,3 +308,323 @@ def synthetic_background_fastas_gz(session_tmpdir, synthetic_background_fastas) 
             dst.write(src.read())
         gz_paths.append(gz_path)
     return gz_paths
+
+
+# ---------------------------------------------------------------------------
+# Reference FASTA matching the contig used by the collection VCF fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def synthetic_collection_reference(session_tmpdir) -> Path:
+    """
+    Reference FASTA for CHROM, the contig `synthetic_collection_vcfs` and
+    `synthetic_collection_vcfs_with_outlier` place their records on. Lets those
+    fixtures be run through the reference-anchored path of `collection`.
+    """
+    rng = np.random.default_rng(909)
+    seq = "".join(rng.choice(list("ACGT"), size=CHROM_LEN).tolist())
+    path = session_tmpdir / "collection_reference.fa"
+    _write_fasta(path, CHROM, seq)
+    return path
+
+
+@pytest.fixture(scope="session")
+def synthetic_collection_reference_gz(session_tmpdir, synthetic_collection_reference) -> Path:
+    """Gzipped version of the collection reference FASTA."""
+    gz_path = session_tmpdir / "collection_reference.fa.gz"
+    with open(synthetic_collection_reference, "rb") as src, gzip.open(gz_path, "wb") as dst:
+        dst.write(src.read())
+    return gz_path
+
+
+# ---------------------------------------------------------------------------
+# Dense VCFs consistent with their reference, for old-path/new-path equivalence
+# ---------------------------------------------------------------------------
+DENSE_CHROM = "NZ_DENSE01.1"
+DENSE_LEN = 2_000
+
+
+@pytest.fixture(scope="session")
+def synthetic_dense_reference(session_tmpdir) -> Path:
+    """A 2 kb reference FASTA for the dense collection fixtures."""
+    rng = np.random.default_rng(4242)
+    seq = "".join(rng.choice(list("ACGT"), size=DENSE_LEN).tolist())
+    path = session_tmpdir / "dense_reference.fa"
+    _write_fasta(path, DENSE_CHROM, seq)
+    return path
+
+
+@pytest.fixture(scope="session")
+def synthetic_dense_vcfs(session_tmpdir, synthetic_dense_reference):
+    """
+    Three bgzipped, CSI-indexed VCFs with a record at *every* reference
+    position, with REF taken from `synthetic_dense_reference`.
+
+    Because they cover every site and agree with the reference, converting them
+    with and without a reference FASTA must give byte-identical alignments —
+    which is the load-bearing check on the reference-anchored fast path.
+
+    Each sample gets its own variant positions, its own low-coverage positions
+    (DP=3, below the -c 5 the tests use), and one missing genotype, so every
+    branch of the base classification is exercised.
+
+    Returns: tuple[Path, Path, Path]
+    """
+    ref_seq = "".join(
+        line.strip()
+        for line in synthetic_dense_reference.read_text().splitlines()[1:]
+    )
+
+    rng = np.random.default_rng(31337)
+    vcfs = []
+
+    for offset, sample_name in enumerate(("dense1", "dense2", "dense3")):
+        vcf_path = session_tmpdir / f"{sample_name}.vcf.gz"
+
+        variants = set(rng.choice(range(1, DENSE_LEN + 1), size=40, replace=False).tolist())
+        low_cov = set(rng.choice(range(1, DENSE_LEN + 1), size=25, replace=False).tolist())
+        missing = {17 + offset}
+
+        header = pysam.VariantHeader()
+        header.add_line("##fileformat=VCFv4.2")
+        header.add_line(f"##contig=<ID={DENSE_CHROM},length={DENSE_LEN}>")
+        header.add_line('##INFO=<ID=DP,Number=1,Type=Integer,Description="Total depth">')
+        header.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+        header.add_sample(sample_name)
+
+        with pysam.VariantFile(vcf_path, "wz", header=header) as vf:
+            for pos in range(1, DENSE_LEN + 1):
+                ref_base = ref_seq[pos - 1]
+                # A deterministic alternate allele that is never the reference.
+                alt_base = "ACGT"[("ACGT".index(ref_base) + 1) % 4]
+
+                rec = vf.new_record()
+                rec.chrom = DENSE_CHROM
+                rec.pos = pos
+                rec.ref = ref_base
+                rec.alts = (alt_base,)
+                rec.qual = 60
+                rec.info["DP"] = 3 if pos in low_cov else 30
+
+                if pos in missing:
+                    rec.samples[sample_name]["GT"] = (None,)
+                else:
+                    rec.samples[sample_name]["GT"] = (1 if pos in variants else 0,)
+
+                vf.write(rec)
+
+        rc = subprocess.run(["bcftools", "index", str(vcf_path)], capture_output=True)
+        if rc.returncode != 0:
+            raise RuntimeError(
+                f"bcftools index failed for {vcf_path}: {rc.stderr.decode()}"
+            )
+        vcfs.append(vcf_path)
+
+    return tuple(vcfs)
+
+
+# ---------------------------------------------------------------------------
+# Multi-contig reference and VCF
+# ---------------------------------------------------------------------------
+MULTI_CONTIGS = (("NZ_MULTI01.1", 300), ("NZ_MULTI02.1", 200))
+
+
+@pytest.fixture(scope="session")
+def synthetic_multicontig_reference(session_tmpdir) -> Path:
+    """A two-contig reference FASTA, for testing global coordinate mapping."""
+    rng = np.random.default_rng(5150)
+    path = session_tmpdir / "multicontig_reference.fa"
+
+    with open(path, "w") as f:
+        for name, length in MULTI_CONTIGS:
+            seq = "".join(rng.choice(list("ACGT"), size=length).tolist())
+            f.write(f">{name}\n")
+            for i in range(0, len(seq), 80):
+                f.write(seq[i:i + 80] + "\n")
+
+    return path
+
+
+@pytest.fixture(scope="session")
+def synthetic_multicontig_vcfs(session_tmpdir, synthetic_multicontig_reference):
+    """
+    Two bgzipped, CSI-indexed VCFs with an alternate call on each of the two
+    contigs of `synthetic_multicontig_reference`, at the same POS on both.
+
+    The shared POS is the point: with the contig ignored, the two records
+    collapse onto one alignment column.
+
+    Returns: tuple[tuple[Path, Path], int]  -- the VCFs and the shared POS.
+    """
+    shared_pos = 50
+    records = {}
+
+    for name, _ in MULTI_CONTIGS:
+        records[name] = shared_pos
+
+    vcfs = []
+    for sample_name in ("multi1", "multi2"):
+        vcf_path = session_tmpdir / f"{sample_name}.multi.vcf.gz"
+
+        header = pysam.VariantHeader()
+        header.add_line("##fileformat=VCFv4.2")
+        for name, length in MULTI_CONTIGS:
+            header.add_line(f"##contig=<ID={name},length={length}>")
+        header.add_line('##INFO=<ID=DP,Number=1,Type=Integer,Description="Total depth">')
+        header.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+        header.add_sample(sample_name)
+
+        with pysam.VariantFile(vcf_path, "wz", header=header) as vf:
+            for chrom, pos in records.items():
+                rec = vf.new_record()
+                rec.chrom = chrom
+                rec.pos = pos
+                rec.ref = "A"
+                rec.alts = ("T",)
+                rec.qual = 60
+                rec.info["DP"] = 30
+                rec.samples[sample_name]["GT"] = (1,)
+                vf.write(rec)
+
+        rc = subprocess.run(["bcftools", "index", str(vcf_path)], capture_output=True)
+        if rc.returncode != 0:
+            raise RuntimeError(
+                f"bcftools index failed for {vcf_path}: {rc.stderr.decode()}"
+            )
+        vcfs.append(vcf_path)
+
+    return tuple(vcfs), shared_pos
+
+
+# ---------------------------------------------------------------------------
+# A larger collection, for the scaling smoke test
+# ---------------------------------------------------------------------------
+MANY_CHROM = "NZ_MANY01.1"
+MANY_LEN = 50_000
+MANY_SAMPLES = 40
+
+
+@pytest.fixture(scope="session")
+def synthetic_many_reference(session_tmpdir) -> Path:
+    """A 50 kb reference for the scaling fixtures."""
+    rng = np.random.default_rng(2718)
+    seq = "".join(rng.choice(list("ACGT"), size=MANY_LEN).tolist())
+    path = session_tmpdir / "many_reference.fa"
+    _write_fasta(path, MANY_CHROM, seq)
+    return path
+
+
+@pytest.fixture(scope="session")
+def synthetic_many_vcfs(session_tmpdir, synthetic_many_reference):
+    """
+    Forty sparse, bgzipped, CSI-indexed VCFs over a 50 kb reference.
+
+    Only variant and low-coverage sites are recorded, which is what a real
+    `cleansweep filter --variants` run produces, so this exercises the fast path
+    at a sample count where the old per-row conversion would dominate.
+
+    Returns: tuple[Path, ...]
+    """
+    ref_seq = "".join(
+        line.strip()
+        for line in synthetic_many_reference.read_text().splitlines()[1:]
+    )
+
+    rng = np.random.default_rng(161803)
+    # A shared core of variants plus a per-sample tail, so the samples are
+    # related without being identical.
+    core = sorted(rng.choice(range(1, MANY_LEN + 1), size=150, replace=False).tolist())
+
+    vcfs = []
+    for i in range(MANY_SAMPLES):
+        vcf_path = session_tmpdir / f"many{i:03d}.vcf.gz"
+
+        private = rng.choice(range(1, MANY_LEN + 1), size=30, replace=False).tolist()
+        low_cov = set(rng.choice(range(1, MANY_LEN + 1), size=20, replace=False).tolist())
+        positions = sorted(set(core) | set(private) | low_cov)
+
+        header = pysam.VariantHeader()
+        header.add_line("##fileformat=VCFv4.2")
+        header.add_line(f"##contig=<ID={MANY_CHROM},length={MANY_LEN}>")
+        header.add_line('##INFO=<ID=DP,Number=1,Type=Integer,Description="Total depth">')
+        header.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+        header.add_sample(f"many{i:03d}")
+
+        with pysam.VariantFile(vcf_path, "wz", header=header) as vf:
+            for pos in positions:
+                ref_base = ref_seq[pos - 1]
+                alt_base = "ACGT"[("ACGT".index(ref_base) + 1) % 4]
+
+                rec = vf.new_record()
+                rec.chrom = MANY_CHROM
+                rec.pos = pos
+                rec.ref = ref_base
+                rec.alts = (alt_base,)
+                rec.qual = 60
+                rec.info["DP"] = 3 if pos in low_cov else 40
+                rec.samples[f"many{i:03d}"]["GT"] = (0 if pos in low_cov else 1,)
+                vf.write(rec)
+
+        rc = subprocess.run(["bcftools", "index", str(vcf_path)], capture_output=True)
+        if rc.returncode != 0:
+            raise RuntimeError(
+                f"bcftools index failed for {vcf_path}: {rc.stderr.decode()}"
+            )
+        vcfs.append(vcf_path)
+
+    return tuple(vcfs)
+
+
+# ---------------------------------------------------------------------------
+# Real `cleansweep filter` output, for an end-to-end collection test
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def filtered_vcfs(session_tmpdir, synthetic_vcf, synthetic_swp):
+    """
+    Three real `cleansweep filter` output VCFs.
+
+    Every other collection fixture is hand-built, so nothing else would catch a
+    change in how `cleansweep filter` writes its FILTER or FORMAT/GT fields —
+    which is exactly what `collection` reads.
+
+    Returns: tuple[Path, Path, Path]
+    """
+    outdir = session_tmpdir / "filtered"
+    outdir.mkdir(exist_ok=True)
+
+    vcfs = []
+    for name in ("f1", "f2", "f3"):
+        rc = subprocess.run(
+            [
+                "cleansweep", "filter",
+                str(synthetic_vcf), str(synthetic_swp), str(outdir / name),
+                "--method", "fast",
+                "-dp", "5", "-a", "5", "-r", "0", "-Nc", "500", "-s", "42", "-V", "0",
+            ],
+            capture_output=True,
+        )
+        if rc.returncode != 0:
+            raise RuntimeError(f"cleansweep filter failed: {rc.stderr.decode()}")
+
+        produced = outdir / name / "cleansweep.variants.vcf"
+        if not produced.exists():
+            raise RuntimeError(f"cleansweep filter wrote no VCF for {name}")
+
+        # Give each one a distinct stem, since collection names records after it.
+        renamed = outdir / f"{name}.vcf"
+        renamed.write_bytes(produced.read_bytes())
+        vcfs.append(renamed)
+
+    return tuple(vcfs)
+
+
+@pytest.fixture(scope="session")
+def filtered_reference(session_tmpdir) -> Path:
+    """
+    Reference FASTA matching `filtered_vcfs`.
+
+    `synthetic_vcf` uses REF="A" at every position, so the reference has to as
+    well for the two conversion paths to be comparable.
+    """
+    path = session_tmpdir / "filtered_reference.fa"
+    _write_fasta(path, CHROM, "A" * CHROM_LEN)
+    return path

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -122,3 +122,342 @@ class TestCollectionExcludeCLI:
         ] + self._base_opts
         rc = subprocess.run(cmd, capture_output=True)
         assert rc.returncode != 0
+
+
+def _fasta_records(fasta_path):
+    """Return an ordered dict of name -> sequence from a FASTA file."""
+    records, name = {}, None
+    with open(fasta_path) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith(">"):
+                name = line[1:]
+                records[name] = ""
+            elif name is not None:
+                records[name] += line
+    return records
+
+
+def _reference_sequence(fasta_path):
+    """Return the concatenated sequence of a reference FASTA."""
+    return "".join(_fasta_records(fasta_path).values())
+
+
+class TestCollectionReferenceCLI:
+    """The reference-anchored fast path."""
+
+    _base_opts = ["--alpha", "10", "-c", "5"]
+
+    def test_returns_zero(
+        self, synthetic_collection_vcfs, synthetic_collection_reference, tmp_path
+    ):
+        vcf_a, vcf_b = synthetic_collection_vcfs
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b),
+            "--output", str(tmp_path / "ref.fasta"),
+            "--reference", str(synthetic_collection_reference),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+    def test_alignment_spans_the_whole_reference(
+        self, synthetic_collection_vcfs, synthetic_collection_reference, tmp_path
+    ):
+        vcf_a, vcf_b = synthetic_collection_vcfs
+        output = tmp_path / "span.fasta"
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b),
+            "--output", str(output),
+            "--reference", str(synthetic_collection_reference),
+        ] + self._base_opts
+        subprocess.run(cmd, capture_output=True, check=True)
+
+        expected = len(_reference_sequence(synthetic_collection_reference))
+        records = _fasta_records(output)
+        assert records, "expected at least one record"
+        assert {len(seq) for seq in records.values()} == {expected}
+
+    def test_invariant_positions_take_the_reference_base(
+        self, synthetic_collection_vcfs, synthetic_collection_reference, tmp_path
+    ):
+        """Position 1 has no record in either VCF, so it must be the reference base."""
+        vcf_a, vcf_b = synthetic_collection_vcfs
+        output = tmp_path / "invariant.fasta"
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b),
+            "--output", str(output),
+            "--reference", str(synthetic_collection_reference),
+        ] + self._base_opts
+        subprocess.run(cmd, capture_output=True, check=True)
+
+        reference = _reference_sequence(synthetic_collection_reference)
+        for seq in _fasta_records(output).values():
+            assert seq[0] == reference[0]
+
+    def test_gzipped_reference_gives_the_same_result(
+        self,
+        synthetic_collection_vcfs,
+        synthetic_collection_reference,
+        synthetic_collection_reference_gz,
+        tmp_path,
+    ):
+        vcf_a, vcf_b = synthetic_collection_vcfs
+        outputs = []
+        for i, ref in enumerate(
+            (synthetic_collection_reference, synthetic_collection_reference_gz)
+        ):
+            output = tmp_path / f"gz_{i}.fasta"
+            cmd = [
+                "cleansweep", "collection",
+                str(vcf_a), str(vcf_b),
+                "--output", str(output),
+                "--reference", str(ref),
+            ] + self._base_opts
+            rc = subprocess.run(cmd, capture_output=True)
+            assert rc.returncode == 0, rc.stderr.decode()
+            outputs.append(output.read_bytes())
+
+        assert outputs[0] == outputs[1]
+
+    def test_missing_reference_fails(
+        self, synthetic_collection_vcfs, tmp_path
+    ):
+        vcf_a, vcf_b = synthetic_collection_vcfs
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b),
+            "--output", str(tmp_path / "missing.fasta"),
+            "--reference", str(tmp_path / "does_not_exist.fa"),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode != 0
+
+
+class TestCollectionReferenceEquivalence:
+    """
+    A VCF covering every reference position must give the same alignment whether
+    or not a reference FASTA is supplied. This is the load-bearing correctness
+    check on the reference-anchored path.
+    """
+
+    def _run(self, vcfs, output, reference, alpha):
+        cmd = [
+            "cleansweep", "collection",
+            *[str(v) for v in vcfs],
+            "--output", str(output),
+            "--alpha", str(alpha),
+            "-c", "5",
+        ]
+        if reference is not None:
+            cmd += ["--reference", str(reference)]
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+        return output
+
+    def test_identical_without_outlier_handling(
+        self, synthetic_dense_vcfs, synthetic_dense_reference, tmp_path
+    ):
+        dense = self._run(synthetic_dense_vcfs, tmp_path / "d.fasta", None, 10)
+        sparse = self._run(
+            synthetic_dense_vcfs, tmp_path / "s.fasta", synthetic_dense_reference, 10
+        )
+        assert dense.read_bytes() == sparse.read_bytes()
+
+    def test_identical_with_private_snp_removal(
+        self, synthetic_dense_vcfs, synthetic_dense_reference, tmp_path
+    ):
+        """A tiny alpha forces the private-SNP branch to run on both paths."""
+        dense = self._run(synthetic_dense_vcfs, tmp_path / "d2.fasta", None, 0.01)
+        sparse = self._run(
+            synthetic_dense_vcfs, tmp_path / "s2.fasta", synthetic_dense_reference, 0.01
+        )
+        assert dense.read_bytes() == sparse.read_bytes()
+
+    def test_alignment_matches_the_reference_length(
+        self, synthetic_dense_vcfs, synthetic_dense_reference, tmp_path
+    ):
+        sparse = self._run(
+            synthetic_dense_vcfs, tmp_path / "s3.fasta", synthetic_dense_reference, 10
+        )
+        expected = len(_reference_sequence(synthetic_dense_reference))
+        assert {len(s) for s in _fasta_records(sparse).values()} == {expected}
+
+    def test_low_coverage_sites_are_n(
+        self, synthetic_dense_vcfs, synthetic_dense_reference, tmp_path
+    ):
+        sparse = self._run(
+            synthetic_dense_vcfs, tmp_path / "s4.fasta", synthetic_dense_reference, 10
+        )
+        records = _fasta_records(sparse)
+        assert any("N" in seq for seq in records.values()), (
+            "the dense fixtures include DP=3 sites, which must become N"
+        )
+
+
+class TestCollectionReferenceOutliers:
+    """Outlier detection must reach the same verdict on the fast path."""
+
+    _base_opts = ["--alpha", "1", "-c", "5"]
+
+    def test_flags_the_same_outlier(
+        self,
+        synthetic_collection_vcfs_with_outlier,
+        synthetic_collection_reference,
+        tmp_path,
+    ):
+        vcf_a, vcf_b, vcf_c = synthetic_collection_vcfs_with_outlier
+        name_a, name_b, name_c = (Path(v).stem for v in (vcf_a, vcf_b, vcf_c))
+        exclude_log = tmp_path / "excluded.txt"
+        cmd = [
+            "cleansweep", "collection",
+            str(vcf_a), str(vcf_b), str(vcf_c),
+            "--output", str(tmp_path / "out.fasta"),
+            "--reference", str(synthetic_collection_reference),
+            "--exclude",
+            "--exclude-log", str(exclude_log),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+        assert exclude_log.read_text().splitlines() == [name_c]
+        names = _fasta_names(tmp_path / "out.fasta")
+        assert name_c not in names
+        assert name_a in names and name_b in names
+
+    def test_without_exclude_keeps_all_samples(
+        self,
+        synthetic_collection_vcfs_with_outlier,
+        synthetic_collection_reference,
+        tmp_path,
+    ):
+        vcfs = synthetic_collection_vcfs_with_outlier
+        expected = {Path(v).stem for v in vcfs}
+        output = tmp_path / "keep.fasta"
+        cmd = [
+            "cleansweep", "collection",
+            *[str(v) for v in vcfs],
+            "--output", str(output),
+            "--reference", str(synthetic_collection_reference),
+        ] + self._base_opts
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+        assert set(_fasta_names(output)) == expected
+
+
+class TestCollectionMultiContig:
+    """
+    Records are placed by contig as well as position. With the contig ignored,
+    two records at the same POS on different contigs collapse onto one column.
+    """
+
+    def test_records_map_to_distinct_columns(
+        self, synthetic_multicontig_vcfs, synthetic_multicontig_reference, tmp_path
+    ):
+        vcfs, shared_pos = synthetic_multicontig_vcfs
+        output = tmp_path / "multi.fasta"
+        cmd = [
+            "cleansweep", "collection",
+            *[str(v) for v in vcfs],
+            "--output", str(output),
+            "--reference", str(synthetic_multicontig_reference),
+            "--alpha", "10", "-c", "5",
+        ]
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+        contigs = _fasta_records(synthetic_multicontig_reference)
+        first_length = len(next(iter(contigs.values())))
+        reference = "".join(contigs.values())
+
+        for seq in _fasta_records(output).values():
+            assert len(seq) == len(reference)
+            assert seq[shared_pos - 1] == "T", "alt on the first contig"
+            assert seq[first_length + shared_pos - 1] == "T", "alt on the second contig"
+
+    def test_alignment_spans_both_contigs(
+        self, synthetic_multicontig_vcfs, synthetic_multicontig_reference, tmp_path
+    ):
+        vcfs, _ = synthetic_multicontig_vcfs
+        output = tmp_path / "multi2.fasta"
+        cmd = [
+            "cleansweep", "collection",
+            *[str(v) for v in vcfs],
+            "--output", str(output),
+            "--reference", str(synthetic_multicontig_reference),
+            "--alpha", "10", "-c", "5",
+        ]
+        subprocess.run(cmd, capture_output=True, check=True)
+
+        expected = len(_reference_sequence(synthetic_multicontig_reference))
+        assert {len(s) for s in _fasta_records(output).values()} == {expected}
+
+
+class TestCollectionScaling:
+    """A collection large enough that the old per-row path would be visible."""
+
+    def test_many_samples(
+        self, synthetic_many_vcfs, synthetic_many_reference, tmp_path
+    ):
+        output = tmp_path / "many.fasta"
+        cmd = [
+            "cleansweep", "collection",
+            *[str(v) for v in synthetic_many_vcfs],
+            "--output", str(output),
+            "--reference", str(synthetic_many_reference),
+            "--alpha", "10", "-c", "5",
+            "--n-threads", "4",
+        ]
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+
+        records = _fasta_records(output)
+        assert len(records) == len(synthetic_many_vcfs)
+
+        expected = len(_reference_sequence(synthetic_many_reference))
+        assert {len(s) for s in records.values()} == {expected}
+
+
+class TestCollectionOnRealFilterOutput:
+    """
+    End-to-end over real `cleansweep filter` output. The other fixtures are
+    hand-built, so this is the only test that would notice `cleansweep filter`
+    changing the FILTER or FORMAT/GT fields that `collection` reads.
+    """
+
+    def _run(self, vcfs, output, reference):
+        cmd = [
+            "cleansweep", "collection",
+            *[str(v) for v in vcfs],
+            "--output", str(output),
+            "--alpha", "10", "-c", "10",
+        ]
+        if reference is not None:
+            cmd += ["--reference", str(reference)]
+        rc = subprocess.run(cmd, capture_output=True)
+        assert rc.returncode == 0, rc.stderr.decode()
+        return output
+
+    def test_both_paths_agree(self, filtered_vcfs, filtered_reference, tmp_path):
+        no_ref = self._run(filtered_vcfs, tmp_path / "no_ref.fasta", None)
+        with_ref = self._run(filtered_vcfs, tmp_path / "with_ref.fasta", filtered_reference)
+        assert no_ref.read_bytes() == with_ref.read_bytes()
+
+    def test_alignment_spans_the_reference(
+        self, filtered_vcfs, filtered_reference, tmp_path
+    ):
+        output = self._run(filtered_vcfs, tmp_path / "span.fasta", filtered_reference)
+        expected = len(_reference_sequence(filtered_reference))
+        records = _fasta_records(output)
+        assert len(records) == len(filtered_vcfs)
+        assert {len(s) for s in records.values()} == {expected}
+
+    def test_low_coverage_sites_become_n(
+        self, filtered_vcfs, filtered_reference, tmp_path
+    ):
+        """`cleansweep filter` marks low-depth sites LowCov; those must be N."""
+        output = self._run(filtered_vcfs, tmp_path / "lowcov.fasta", filtered_reference)
+        for seq in _fasta_records(output).values():
+            assert "N" in seq

--- a/tests/test_collection_logic.py
+++ b/tests/test_collection_logic.py
@@ -1,8 +1,16 @@
 """Unit tests for Collection logic — no CLI, no multi-process I/O."""
+import gzip
+
 import numpy as np
 import pytest
+from scipy.spatial.distance import hamming
 
-from cleansweep.collection import Collection
+from cleansweep.collection import (
+    Collection,
+    combine_duplicates,
+    load_reference,
+    pack_sequences,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -100,113 +108,286 @@ class TestVcfToSeq:
 
 
 # ---------------------------------------------------------------------------
-# TestFindOutliers
+# Fixtures for the reference-anchored path
 # ---------------------------------------------------------------------------
 
-class TestFindOutliers:
+@pytest.fixture(scope="module")
+def chr1_reference(tmp_path_factory):
+    """A 3 bp reference for CHR1, the contig `simple_vcf` uses. Bases A, C, G."""
+    d = tmp_path_factory.mktemp("chr1_ref")
+    p = d / "chr1.fa"
+    p.write_text(">CHR1\nACG\n")
+    return p
 
-    def test_single_sequence_returns_empty(self, col):
-        assert col.find_outliers({"s1": "AAAA"}) == []
 
-    def test_two_identical_no_outlier(self, col):
-        seqs = {"s1": "AAAA", "s2": "AAAA"}
-        assert col.find_outliers(seqs, alpha=1.0) == []
-
-    def test_divergent_sample_flagged(self, col):
-        similar = "A" * 50
-        outlier = "T" * 50
-        seqs = {f"s{i}": similar for i in range(4)}
-        seqs["sOUT"] = outlier
-        result = col.find_outliers(seqs, alpha=1.0)
-        assert "sOUT" in result
-        assert all(f"s{i}" not in result for i in range(4))
-
-    def test_all_similar_large_alpha_no_outlier(self, col):
-        rng = np.random.default_rng(42)
-        seqs = {
-            f"s{i}": "".join(rng.choice(list("ACGT"), size=40).tolist())
-            for i in range(5)
-        }
-        result = col.find_outliers(seqs, alpha=10.0)
-        assert result == []
+@pytest.fixture(scope="module")
+def two_contig_reference(tmp_path_factory):
+    """A reference with two 4 bp contigs, for global coordinate mapping."""
+    d = tmp_path_factory.mktemp("two_contig")
+    p = d / "two.fa"
+    p.write_text(">C1\nAAAA\n>C2\nCCCC\n")
+    return p
 
 
 # ---------------------------------------------------------------------------
-# TestConsensusSequence
+# TestLoadReference
 # ---------------------------------------------------------------------------
 
-class TestConsensusSequence:
+class TestLoadReference:
 
-    def test_unanimous_position(self, col):
-        seqs = {"s1": "AAA", "s2": "AAA", "s3": "AAA"}
-        cons = col.consensus_sequence(seqs)
-        assert list(cons) == ["A", "A", "A"]
+    def test_single_contig_sequence(self, chr1_reference):
+        reference, _, _ = load_reference(chr1_reference)
+        assert reference.tobytes().decode() == "ACG"
 
-    def test_majority_wins(self, col):
-        seqs = {"s1": "AATG", "s2": "AACG", "s3": "AATG"}
-        cons = col.consensus_sequence(seqs)
-        assert cons[2] == "T"
+    def test_single_contig_offsets_and_lengths(self, chr1_reference):
+        _, offsets, lengths = load_reference(chr1_reference)
+        assert offsets == {"CHR1": 0}
+        assert lengths == {"CHR1": 3}
 
-    def test_n_ignored_in_consensus(self, col):
-        seqs = {"s1": "NTG", "s2": "ATG", "s3": "ATG"}
-        cons = col.consensus_sequence(seqs)
-        assert cons[0] == "A"
+    def test_contigs_are_concatenated_in_file_order(self, two_contig_reference):
+        reference, offsets, lengths = load_reference(two_contig_reference)
+        assert reference.tobytes().decode() == "AAAACCCC"
+        assert offsets == {"C1": 0, "C2": 4}
+        assert lengths == {"C1": 4, "C2": 4}
 
-    def test_empty_sequences_raises(self, col):
+    def test_lowercase_is_upcased(self, tmp_path):
+        p = tmp_path / "lower.fa"
+        p.write_text(">C1\nacgt\n")
+        reference, _, _ = load_reference(p)
+        assert reference.tobytes().decode() == "ACGT"
+
+    def test_gzipped_reference(self, tmp_path, chr1_reference):
+        gz = tmp_path / "chr1.fa.gz"
+        with gzip.open(gz, "wt") as f:
+            f.write(chr1_reference.read_text())
+        reference, offsets, _ = load_reference(gz)
+        assert reference.tobytes().decode() == "ACG"
+        assert offsets == {"CHR1": 0}
+
+    def test_empty_fasta_raises(self, tmp_path):
+        p = tmp_path / "empty.fa"
+        p.write_text("")
         with pytest.raises(ValueError):
-            col.consensus_sequence({})
+            load_reference(p)
 
-    def test_output_length_matches_sequence_length(self, col):
-        seqs = {"s1": "ACGT", "s2": "ACGT"}
-        assert len(col.consensus_sequence(seqs)) == 4
-
-
-# ---------------------------------------------------------------------------
-# TestRemovePrivateSnps
-# ---------------------------------------------------------------------------
-
-class TestRemovePrivateSnps:
-
-    def test_private_snp_replaced_with_consensus(self, col):
-        target = "ATCG"
-        others = {"s2": "TTCG", "s3": "TTCG"}
-        consensus = np.array(["T", "T", "C", "G"])
-        result = col.remove_private_snps(target, others, consensus)
-        assert result[0] == "T", "private A → replaced with consensus T"
-
-    def test_shared_snp_kept(self, col):
-        target = "ATCG"
-        others = {"s2": "ATCG"}
-        consensus = np.array(["A", "T", "C", "G"])
-        result = col.remove_private_snps(target, others, consensus)
-        assert result == "ATCG"
-
-    def test_output_same_length_as_input(self, col):
-        target = "AAAA"
-        others = {"s2": "TTTT"}
-        consensus = np.array(["T", "T", "T", "T"])
-        result = col.remove_private_snps(target, others, consensus)
-        assert len(result) == 4
-
-
-# ---------------------------------------------------------------------------
-# TestWriteMsa
-# ---------------------------------------------------------------------------
-
-class TestWriteMsa:
-
-    def test_fasta_format(self, col, tmp_path):
-        seqs = {"s1": "ATCG", "s2": "ATCG"}
-        out = tmp_path / "out.fasta"
-        col.write_msa(seqs, out)
-        content = out.read_text()
-        assert content == ">s1\nATCG\n>s2\nATCG\n"
-
-    def test_raises_on_different_lengths(self, col, tmp_path):
+    def test_duplicate_contig_raises(self, tmp_path):
+        p = tmp_path / "dup.fa"
+        p.write_text(">C1\nAAAA\n>C1\nCCCC\n")
         with pytest.raises(ValueError):
-            col.write_msa({"s1": "AT", "s2": "ATCG"}, tmp_path / "bad.fasta")
+            load_reference(p)
 
-    def test_creates_file(self, col, tmp_path):
-        out = tmp_path / "out2.fasta"
-        col.write_msa({"s1": "ACGT"}, out)
-        assert out.exists() and out.stat().st_size > 0
+
+# ---------------------------------------------------------------------------
+# TestVcfToSparse
+# ---------------------------------------------------------------------------
+
+class TestVcfToSparse:
+
+    def test_selects_only_non_reference_records(self, col, simple_vcf, chr1_reference):
+        """pos 2 is a covered reference call, so it must not be reported."""
+        _, offsets, lengths = load_reference(chr1_reference)
+        positions, _ = col.vcf_to_sparse(
+            vcf=simple_vcf, offsets=offsets, lengths=lengths, min_dp=10
+        )
+        assert positions.tolist() == [0, 2], "0-based indices of pos 1 and pos 3"
+
+    def test_alt_and_low_coverage_codes(self, col, simple_vcf, chr1_reference):
+        _, offsets, lengths = load_reference(chr1_reference)
+        _, codes = col.vcf_to_sparse(
+            vcf=simple_vcf, offsets=offsets, lengths=lengths, min_dp=10
+        )
+        assert codes.tobytes().decode() == "TN", "pos 1 is alt T, pos 3 is low coverage"
+
+    def test_unknown_contig_raises(self, col, simple_vcf, two_contig_reference):
+        _, offsets, lengths = load_reference(two_contig_reference)
+        with pytest.raises(ValueError, match="absent from the reference"):
+            col.vcf_to_sparse(
+                vcf=simple_vcf, offsets=offsets, lengths=lengths, min_dp=10
+            )
+
+    def test_position_past_contig_end_raises(self, col, simple_vcf, tmp_path):
+        short = tmp_path / "short.fa"
+        short.write_text(">CHR1\nAC\n")
+        _, offsets, lengths = load_reference(short)
+        with pytest.raises(ValueError, match="outside"):
+            col.vcf_to_sparse(
+                vcf=simple_vcf, offsets=offsets, lengths=lengths, min_dp=10
+            )
+
+    def test_second_contig_is_offset(self, col, tmp_path, two_contig_reference):
+        """A record on C2 must land past the end of C1."""
+        p = tmp_path / "c2.vcf"
+        p.write_text(
+            "##fileformat=VCFv4.2\n"
+            "##contig=<ID=C1,length=4>\n"
+            "##contig=<ID=C2,length=4>\n"
+            '##INFO=<ID=DP,Number=1,Type=Integer,Description="Depth">\n'
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n"
+            "C1\t2\t.\tA\tT\t60\tPASS\tDP=30\tGT\t1\n"
+            "C2\t2\t.\tC\tG\t60\tPASS\tDP=30\tGT\t1\n"
+        )
+        _, offsets, lengths = load_reference(two_contig_reference)
+        positions, codes = col.vcf_to_sparse(
+            vcf=p, offsets=offsets, lengths=lengths, min_dp=10
+        )
+        assert positions.tolist() == [1, 5], "C1:2 -> 1, C2:2 -> 4 + 1"
+        assert codes.tobytes().decode() == "TG"
+
+
+# ---------------------------------------------------------------------------
+# TestCombineDuplicates
+# ---------------------------------------------------------------------------
+
+class TestCombineDuplicates:
+
+    def _codes(self, s):
+        return np.frombuffer(s.encode(), dtype=np.uint8)
+
+    def test_no_duplicates_passes_through(self):
+        pos, codes = combine_duplicates(np.array([5, 1, 3]), self._codes("ACG"))
+        assert pos.tolist() == [1, 3, 5]
+        assert codes.tobytes().decode() == "CGA"
+
+    def test_two_distinct_bases_become_iupac(self):
+        pos, codes = combine_duplicates(np.array([7, 7]), self._codes("AG"))
+        assert pos.tolist() == [7]
+        assert codes.tobytes().decode() == "R", "A + G is IUPAC R"
+
+    def test_iupac_is_order_independent(self):
+        _, forward = combine_duplicates(np.array([7, 7]), self._codes("CT"))
+        _, reverse = combine_duplicates(np.array([7, 7]), self._codes("TC"))
+        assert forward.tobytes() == reverse.tobytes() == b"Y"
+
+    def test_repeated_identical_base_is_kept(self):
+        _, codes = combine_duplicates(np.array([2, 2]), self._codes("TT"))
+        assert codes.tobytes().decode() == "T"
+
+    def test_any_ambiguous_record_wins(self):
+        _, codes = combine_duplicates(np.array([2, 2]), self._codes("AN"))
+        assert codes.tobytes().decode() == "N"
+
+    def test_three_bases_become_iupac(self):
+        _, codes = combine_duplicates(np.array([1, 1, 1]), self._codes("ACG"))
+        assert codes.tobytes().decode() == "V", "A + C + G is IUPAC V"
+
+
+# ---------------------------------------------------------------------------
+# TestMaxIdentities
+# ---------------------------------------------------------------------------
+
+class TestMaxIdentities:
+
+    def test_identical_rows_are_fully_identical(self):
+        matrix, length = pack_sequences(["ACGT", "ACGT"])
+        assert Collection.max_identities(matrix, length).tolist() == [1.0, 1.0]
+
+    def test_single_row_returns_one(self):
+        matrix, length = pack_sequences(["ACGT"])
+        assert Collection.max_identities(matrix, length).tolist() == [1.0]
+
+    def test_matches_scipy_hamming(self):
+        seqs = ["AAAACCCC", "AAAACCCG", "TTTTGGGG"]
+        matrix, length = pack_sequences(seqs)
+        identities = Collection.max_identities(matrix, length)
+        expected = [
+            max(1 - hamming(list(a), list(b)) for j, b in enumerate(seqs) if i != j)
+            for i, a in enumerate(seqs)
+        ]
+        assert identities == pytest.approx(expected)
+
+    def test_denominator_is_total_length_not_column_count(self):
+        """
+        The sparse contract: two rows differing at 1 of 2 held columns, out of a
+        1000 bp alignment, are 999/1000 identical -- not 1/2.
+        """
+        matrix, _ = pack_sequences(["AC", "AG"])
+        identities = Collection.max_identities(matrix, total_length=1000)
+        assert identities == pytest.approx([0.999, 0.999])
+
+
+# ---------------------------------------------------------------------------
+# TestOutlierIndices
+# ---------------------------------------------------------------------------
+
+class TestOutlierIndices:
+
+    def test_fewer_than_two_rows_returns_empty(self):
+        matrix, length = pack_sequences(["ACGT"])
+        assert Collection.outlier_indices(matrix, length, alpha=1.0) == []
+
+    def test_zero_length_returns_empty(self):
+        matrix, _ = pack_sequences(["", ""])
+        assert Collection.outlier_indices(matrix, 0, alpha=1.0) == []
+
+    def test_sparse_and_dense_agree(self):
+        """
+        Dropping the columns where every row agrees must not change the verdict.
+        """
+        dense = ["A" * 20 + "C", "A" * 20 + "C", "A" * 20 + "G"]
+        dense_matrix, dense_length = pack_sequences(dense)
+        # Only the last column varies, so that is the whole sparse alignment.
+        sparse_matrix, _ = pack_sequences(["C", "C", "G"])
+        assert (
+            Collection.outlier_indices(sparse_matrix, dense_length, alpha=0.5)
+            == Collection.outlier_indices(dense_matrix, dense_length, alpha=0.5)
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestConsensusFromMatrix
+# ---------------------------------------------------------------------------
+
+class TestConsensusFromMatrix:
+
+    def test_majority_wins(self):
+        matrix, _ = pack_sequences(["AATG", "AACG", "AATG"])
+        assert Collection.consensus_from_matrix(matrix).tobytes().decode() == "AATG"
+
+    def test_n_is_ignored(self):
+        matrix, _ = pack_sequences(["NTG", "ATG", "ATG"])
+        assert Collection.consensus_from_matrix(matrix).tobytes().decode() == "ATG"
+
+    def test_all_ambiguous_column_is_n(self):
+        matrix, _ = pack_sequences(["N.", "NN"])
+        assert Collection.consensus_from_matrix(matrix).tobytes().decode() == "NN"
+
+    def test_tie_resolves_to_smallest_base(self):
+        matrix, _ = pack_sequences(["A", "T"])
+        assert Collection.consensus_from_matrix(matrix).tobytes().decode() == "A"
+
+    def test_empty_matrix_raises(self):
+        with pytest.raises(ValueError):
+            Collection.consensus_from_matrix(np.empty((0, 4), dtype=np.uint8))
+
+
+# ---------------------------------------------------------------------------
+# TestRemovePrivateFromMatrix
+# ---------------------------------------------------------------------------
+
+class TestRemovePrivateFromMatrix:
+
+    def test_private_base_replaced_with_consensus(self):
+        matrix, _ = pack_sequences(["ATCG", "TTCG", "TTCG"])
+        consensus = np.frombuffer(b"TTCG", dtype=np.uint8)
+        Collection.remove_private_from_matrix(matrix, 0, consensus)
+        assert matrix[0].tobytes().decode() == "TTCG"
+
+    def test_shared_base_kept(self):
+        matrix, _ = pack_sequences(["ATCG", "ATCG"])
+        consensus = np.frombuffer(b"TTTT", dtype=np.uint8)
+        Collection.remove_private_from_matrix(matrix, 0, consensus)
+        assert matrix[0].tobytes().decode() == "ATCG"
+
+    def test_other_rows_untouched(self):
+        matrix, _ = pack_sequences(["ATCG", "TTCG", "TTCG"])
+        consensus = np.frombuffer(b"TTCG", dtype=np.uint8)
+        Collection.remove_private_from_matrix(matrix, 0, consensus)
+        assert matrix[1].tobytes().decode() == "TTCG"
+        assert matrix[2].tobytes().decode() == "TTCG"
+
+    def test_single_row_is_a_no_op(self):
+        matrix, _ = pack_sequences(["ATCG"])
+        Collection.remove_private_from_matrix(matrix, 0, np.frombuffer(b"TTTT", dtype=np.uint8))
+        assert matrix[0].tobytes().decode() == "ATCG"
+


### PR DESCRIPTION
This pull request adds support for reference-anchored multiple sequence alignment in the `cleansweep collection` workflow, significantly improving performance and scalability for large sample collections. The new `--reference` option allows CleanSweep to reconstruct alignments by patching variant and low-coverage sites into a reference sequence, rather than expanding every VCF record, resulting in much faster and more memory-efficient processing. The documentation and test suite are updated to reflect and validate this new feature.

**Reference-anchored alignment and CLI improvements:**

* Added a `--reference` (`-r`) argument to `cleansweep collection`, allowing users to specify the reference FASTA used for variant calling. This enables a fast path where only variant and low-coverage sites are read from each VCF and patched into the reference, greatly improving speed and scalability for large collections. [[1]](diffhunk://#diff-558979f86cbd1e1466d4a1fe82824f47b30b634a2b17e6290031af8c852eba02R36-R44) [[2]](diffhunk://#diff-558979f86cbd1e1466d4a1fe82824f47b30b634a2b17e6290031af8c852eba02R83) [[3]](diffhunk://#diff-558979f86cbd1e1466d4a1fe82824f47b30b634a2b17e6290031af8c852eba02R92-R104)
* Updated the documentation in `README.md` and `docs/usage.rst` to explain the new `--reference` option, its benefits, and its effect on alignment behavior and performance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R130) [[2]](diffhunk://#diff-c4b284a0e8c330264ebefb4d3d14dd5bb68fe3b72c2ae656f49132e2c134b84fR87) [[3]](diffhunk://#diff-c4b284a0e8c330264ebefb4d3d14dd5bb68fe3b72c2ae656f49132e2c134b84fR97-R118)

**VCF reading and robustness improvements:**

* Improved the VCF reading logic in `cleansweep/vcf.py` to robustly handle VCFs with no data records by deriving column names from the header and returning a correctly-typed empty DataFrame when necessary. Also added a `filter_indels` parameter to allow optional indel filtering. [[1]](diffhunk://#diff-2b8eed86d39d814dda26747a79b97aea4c2d3afc2ec9d565066a2c30a08fe2f2L52-R53) [[2]](diffhunk://#diff-2b8eed86d39d814dda26747a79b97aea4c2d3afc2ec9d565066a2c30a08fe2f2L82-R113)

**Test suite enhancements:**

* Added new synthetic reference and VCF fixtures in `tests/conftest.py` to test the reference-anchored path, including dense and sparse VCFs, multi-contig references, and large-scale collections. This ensures correctness and performance of the new alignment mode.